### PR TITLE
feat(auth): set tokens as HTTP-only cookies during login

### DIFF
--- a/src/token/token.service.ts
+++ b/src/token/token.service.ts
@@ -40,7 +40,7 @@ export class TokenService {
         ? previousRefreshToken
         : this.jwtService.sign(payload as Payload, {
             secret: variables.jwtRefreshSecret,
-            expiresIn: '7d',
+            expiresIn: variables.jwtRefreshTokenExpiresIn,
           });
       return { accessToken, refreshToken };
     } catch (error) {


### PR DESCRIPTION
- Added `@Res` decorator to `login` method in `AuthController` to set HTTP-only cookies for access and refresh tokens.
- Updated `TokenService` to use `variables.jwtRefreshTokenExpiresIn` for refresh token expiration.
- Ensured cookies are set with `httpOnly`, `secure`, and `sameSite` options for enhanced security.