### PR TITLE
Simplify dist verification step and improve readability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,6 @@ jobs:
         run: pnpm test:cov
 
       - name: Upload coverage report
-        # Upload once — from the primary Node version on push only.
         if: matrix.node-version == '24' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
@@ -122,9 +121,15 @@ jobs:
         run: pnpm build
 
       - name: Verify dist exports
-        # Smoke-check that the compiled package is importable as consumers
-        # would use it — catches broken re-exports or missing declarations.
-        run: node -e "const m = require('./dist/index.js'); const required = ['AuthModule','AuthService','JwtAuthGuard']; required.forEach(k => { if (!m[k]) throw new Error('Missing export: ' + k); }); console.log('Export smoke check passed');"
+        run: |
+          node <<EOF
+          const m = require('./dist/index.js');
+          const required = ['AuthModule','AuthService','JwtAuthGuard'];
+          required.forEach(k => {
+            if (!m[k]) throw new Error('Missing export: ' + k);
+          });
+          console.log('Export smoke check passed');
+          EOF
 
       - name: Upload dist
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Replace inline node command with heredoc for better readability
- Remove redundant comment line from coverage upload step

## Summary
<!-- What does this PR do? One paragraph. -->

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change, no behaviour change
- [ ] `docs` — documentation only
- [ ] `chore` — build, deps, tooling
- [ ] `test` — test changes only
- [x] `ci` — CI/CD changes

## Breaking changes
- [ ] This PR introduces a breaking change

<!-- If yes, describe what breaks and the migration path. -->

## Checklist
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Types are correct — `pnpm typecheck` passes
- [ ] No lint errors — `pnpm lint:check` passes
- [ ] Tests added / updated for changed behaviour
- [ ] `pnpm test:cov` passes with ≥ 80 % coverage
- [ ] Public API changes are reflected in the README
