### PR TITLE
Fix release workflow to wait for full CI run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
       - name: Wait for CI workflow to complete
         uses: lewagon/wait-on-check-action@v1.5.0
         with:
-          ref: ${{ github.ref }}
-          check-name: "Build"          # The final job in ci.yml
+          ref: ${{ github.sha }}
+          check-name: "CI"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20            # Poll every 20 seconds
+          wait-interval: 20
           allowed-conclusions: success
 
   # ── Release ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph. -->

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change, no behaviour change
- [ ] `docs` — documentation only
- [ ] `chore` — build, deps, tooling
- [ ] `test` — test changes only
- [x] `ci` — CI/CD changes

## Breaking changes
- [ ] This PR introduces a breaking change

<!-- If yes, describe what breaks and the migration path. -->

## Checklist
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Types are correct — `pnpm typecheck` passes
- [ ] No lint errors — `pnpm lint:check` passes
- [ ] Tests added / updated for changed behaviour
- [ ] `pnpm test:cov` passes with ≥ 80 % coverage
- [ ] Public API changes are reflected in the README
