### PR TITLE
Replace wait-on-check with workflow_run trigger for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,61 +1,55 @@
 name: Release
 
 on:
-  push:
-    branches: [main, beta, alpha]
+  workflow_run:
+    workflows: ["CI"]   # Must match exactly your CI workflow name
+    types:
+      - completed
 
-# Only one release at a time — never run concurrently.
+# Only one release at a time
 concurrency:
   group: release
   cancel-in-progress: false
 
 jobs:
-  # ── Gate: wait for CI to pass on this exact commit ─────────────────────────
-  # This job polls the ci.yml workflow until it succeeds or fails.
-  # A release is never published from a commit where CI is red.
-  wait-for-ci:
-    name: Wait for CI
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for CI workflow to complete
-        uses: lewagon/wait-on-check-action@v1.5.0
-        with:
-          ref: ${{ github.sha }}
-          check-name: "CI"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 20
-          allowed-conclusions: success
-
-  # ── Release ────────────────────────────────────────────────────────────────
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
-    needs: wait-for-ci
+
+    # Only run if CI succeeded AND it's one of your release branches
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      (
+        github.event.workflow_run.head_branch == 'main' ||
+        github.event.workflow_run.head_branch == 'beta' ||
+        github.event.workflow_run.head_branch == 'alpha'
+      )
+
     permissions:
-      contents: write       # push CHANGELOG.md + version tag
-      issues: write         # comment on resolved issues
-      pull-requests: write  # comment on merged PRs
-      id-token: write       # npm provenance (SLSA)
+      contents: write
+      issues: write
+      pull-requests: write
+      id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          # Full history needed for semantic-release to analyse commits.
           fetch-depth: 0
-          # Use a PAT so the release commit bypasses branch protection.
-          # Set RELEASE_TOKEN in repo secrets (or fall back to GITHUB_TOKEN
-          # if branch protection doesn't block the bot).
+          # Checkout the exact commit CI ran on
+          ref: ${{ github.event.workflow_run.head_sha }}
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
           cache: pnpm
-          # Authenticate to the npm registry for publishing.
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
@@ -64,7 +58,7 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Release
+      - name: Run Semantic Release
         run: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,11 @@ name: Release
 
 on:
   workflow_run:
-    workflows: ["CI"]   # Must match exactly your CI workflow name
+    workflows: ["CI"]
     types:
       - completed
+    branches: [main, beta, alpha]
 
-# Only one release at a time
 concurrency:
   group: release
   cancel-in-progress: false
@@ -16,14 +16,15 @@ jobs:
     name: Semantic Release
     runs-on: ubuntu-latest
 
-    # Only run if CI succeeded AND it's one of your release branches
     if: >
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
       (
         github.event.workflow_run.head_branch == 'main' ||
         github.event.workflow_run.head_branch == 'beta' ||
         github.event.workflow_run.head_branch == 'alpha'
-      )
+      ) &&
+      github.event.workflow_run.head_repository.full_name == github.repository
 
     permissions:
       contents: write
@@ -36,7 +37,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # Checkout the exact commit CI ran on
           ref: ${{ github.event.workflow_run.head_sha }}
           token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph. -->

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change, no behaviour change
- [ ] `docs` — documentation only
- [ ] `chore` — build, deps, tooling
- [ ] `test` — test changes only
- [x] `ci` — CI/CD changes

## Breaking changes
- [ ] This PR introduces a breaking change

<!-- If yes, describe what breaks and the migration path. -->

## Checklist
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Types are correct — `pnpm typecheck` passes
- [ ] No lint errors — `pnpm lint:check` passes
- [ ] Tests added / updated for changed behaviour
- [ ] `pnpm test:cov` passes with ≥ 80 % coverage
- [ ] Public API changes are reflected in the README
