### PR TITLE
chore: add conventional commits preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "argon2": "^0.44.0",
+    "conventional-changelog-conventionalcommits": "^9.3.0",
     "eslint": "^9.0.0",
     "eslint-config-prettier": "^9.1.2",
     "eslint-plugin-prettier": "^5.5.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.57.1
         version: 8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.3.0
+        version: 9.3.0
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -1250,6 +1253,10 @@ packages:
 
   conventional-changelog-angular@8.3.0:
     resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.3.0:
+    resolution: {integrity: sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==}
     engines: {node: '>=18'}
 
   conventional-changelog-writer@8.4.0:
@@ -4706,6 +4713,10 @@ snapshots:
   content-type@1.0.5: {}
 
   conventional-changelog-angular@8.3.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph. -->

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change, no behaviour change
- [ ] `docs` — documentation only
- [x] `chore` — build, deps, tooling
- [ ] `test` — test changes only
- [ ] `ci` — CI/CD changes

## Breaking changes
- [ ] This PR introduces a breaking change

<!-- If yes, describe what breaks and the migration path. -->

## Checklist
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Types are correct — `pnpm typecheck` passes
- [ ] No lint errors — `pnpm lint:check` passes
- [ ] Tests added / updated for changed behaviour
- [ ] `pnpm test:cov` passes with ≥ 80 % coverage
- [ ] Public API changes are reflected in the README
