### PR TITLE
chore(release): remove @semantic-release/git plugin

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,8 +1,14 @@
 {
   "branches": [
     "main",
-    { "name": "beta", "prerelease": true },
-    { "name": "alpha", "prerelease": true }
+    {
+      "name": "beta",
+      "prerelease": true
+    },
+    {
+      "name": "alpha",
+      "prerelease": true
+    }
   ],
   "plugins": [
     [
@@ -10,16 +16,46 @@
       {
         "preset": "conventionalcommits",
         "releaseRules": [
-          { "type": "feat",     "release": "minor" },
-          { "type": "fix",      "release": "patch" },
-          { "type": "perf",     "release": "patch" },
-          { "type": "refactor", "release": "patch" },
-          { "type": "docs",     "release": false   },
-          { "type": "style",    "release": false   },
-          { "type": "test",     "release": false   },
-          { "type": "chore",    "release": false   },
-          { "type": "ci",       "release": false   },
-          { "breaking": true,   "release": "major" }
+          {
+            "type": "feat",
+            "release": "minor"
+          },
+          {
+            "type": "fix",
+            "release": "patch"
+          },
+          {
+            "type": "perf",
+            "release": "patch"
+          },
+          {
+            "type": "refactor",
+            "release": "patch"
+          },
+          {
+            "type": "docs",
+            "release": false
+          },
+          {
+            "type": "style",
+            "release": false
+          },
+          {
+            "type": "test",
+            "release": false
+          },
+          {
+            "type": "chore",
+            "release": false
+          },
+          {
+            "type": "ci",
+            "release": false
+          },
+          {
+            "breaking": true,
+            "release": "major"
+          }
         ]
       }
     ],
@@ -29,14 +65,39 @@
         "preset": "conventionalcommits",
         "presetConfig": {
           "types": [
-            { "type": "feat",     "section": "Features"          },
-            { "type": "fix",      "section": "Bug Fixes"         },
-            { "type": "perf",     "section": "Performance"       },
-            { "type": "refactor", "section": "Refactoring"       },
-            { "type": "docs",     "section": "Documentation", "hidden": true },
-            { "type": "chore",    "hidden": true                 },
-            { "type": "test",     "hidden": true                 },
-            { "type": "ci",       "hidden": true                 }
+            {
+              "type": "feat",
+              "section": "Features"
+            },
+            {
+              "type": "fix",
+              "section": "Bug Fixes"
+            },
+            {
+              "type": "perf",
+              "section": "Performance"
+            },
+            {
+              "type": "refactor",
+              "section": "Refactoring"
+            },
+            {
+              "type": "docs",
+              "section": "Documentation",
+              "hidden": true
+            },
+            {
+              "type": "chore",
+              "hidden": true
+            },
+            {
+              "type": "test",
+              "hidden": true
+            },
+            {
+              "type": "ci",
+              "hidden": true
+            }
           ]
         }
       }
@@ -51,13 +112,6 @@
       "@semantic-release/npm",
       {
         "npmPublish": true
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"


### PR DESCRIPTION
Remove the Git plugin so semantic-release no longer attempts to commit back to the repository. This avoids permission issues and aligns with the workflow_run trigger.

## Summary
<!-- What does this PR do? One paragraph. -->

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change, no behaviour change
- [ ] `docs` — documentation only
- [x] `chore` — build, deps, tooling
- [ ] `test` — test changes only
- [ ] `ci` — CI/CD changes

## Breaking changes
- [ ] This PR introduces a breaking change

<!-- If yes, describe what breaks and the migration path. -->

## Checklist
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Types are correct — `pnpm typecheck` passes
- [ ] No lint errors — `pnpm lint:check` passes
- [ ] Tests added / updated for changed behaviour
- [ ] `pnpm test:cov` passes with ≥ 80 % coverage
- [ ] Public API changes are reflected in the README
