### PR TITLE
Add typed error codes and logger port for framework independence

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,20 @@ allowed to do. Authorization is your application's concern.
   or `Bearer header` → a cookie by passing one class. Zero changes to core logic.
 - **Capability flags.** Enable only the auth methods you need.
 - **True refresh-token rotation.** One-time-use tokens, atomically consumed, SHA-256 hashed.
+- **Framework-agnostic core.** `AuthService` is a plain class — use it with NestJS,
+  plain Fastify, Express, Lambda, or any other runtime. The NestJS adapter layer
+  (strategies, guards, decorators, module) is the only part that requires NestJS.
 
 ## Architecture
 
 ```
 interfaces/ports/   ← contracts (zero deps — the inversion anchor)
       ↑
-  adapters/         ← default implementations of the four internal ports
+  adapters/         ← default implementations of the five internal ports
       ↑
     core/           ← AuthService + AuthModule (use-cases, wiring)
   strategies/       ← Passport strategies
+  filters/          ← AuthExceptionFilter (NestJS HTTP adapter)
     guards/         ← JwtAuthGuard, GoogleOAuthGuard
  decorators/        ← @CurrentUser(), @Public()
 ```
@@ -41,6 +45,55 @@ interfaces/ports/   ← contracts (zero deps — the inversion anchor)
 | Password hashing | `IPasswordHasher` | `Argon2PasswordHasher` (argon2id) | `passwordHasher:` |
 | Token hashing / generation | `ITokenHasher` | `CryptoTokenHasher` (node:crypto) | `tokenHasher:` |
 | JWT extraction from request | `ITokenExtractor` | `BearerTokenExtractor` (Authorization header) | `tokenExtractor:` |
+| Logging | `ILogger` | `ConsoleLogger` (console.log / console.error) | `logger:` |
+
+## Error handling
+
+`AuthService` throws `AuthError` with a typed `AuthErrorCode` — never HTTP-specific
+exceptions. This keeps the core framework-agnostic and gives consumers full control
+over how errors are surfaced.
+
+**NestJS users:** register `AuthExceptionFilter` to map error codes to HTTP responses:
+
+```ts
+// app.module.ts
+providers: [
+  { provide: APP_GUARD,  useClass: JwtAuthGuard },
+  { provide: APP_FILTER, useClass: AuthExceptionFilter },
+]
+```
+
+**Non-NestJS users:** catch `AuthError` and map `err.code` yourself:
+
+```ts
+import { AuthError, AuthErrorCode } from '@odysseon/auth';
+
+try {
+  await authService.loginWithCredentials(input);
+} catch (err) {
+  if (err instanceof AuthError) {
+    switch (err.code) {
+      case AuthErrorCode.INVALID_CREDENTIALS: return reply.status(401).send();
+      case AuthErrorCode.EMAIL_ALREADY_EXISTS: return reply.status(409).send();
+    }
+  }
+  throw err;
+}
+```
+
+### Error code → HTTP status map
+
+| `AuthErrorCode` | Default HTTP status | Thrown by |
+|---|---|---|
+| `INVALID_CREDENTIALS` | 401 | `loginWithCredentials`, `changePassword` (wrong current password) |
+| `EMAIL_ALREADY_EXISTS` | 409 | `register` |
+| `OAUTH_ACCOUNT_NO_PASSWORD` | 400 | `changePassword`, `setPassword` (OAuth-only account) |
+| `PASSWORD_SAME_AS_OLD` | 400 | `changePassword` |
+| `USER_NOT_FOUND` | 404 | `changePassword`, `setPassword`, `rotateRefreshToken` (deleted user) |
+| `OAUTH_USER_NOT_FOUND` | 401 | `handleGoogleCallback` (user vanished after OAuth) |
+| `REFRESH_TOKEN_INVALID` | 401 | `rotateRefreshToken` (bad/used token), `verifyAccessToken` |
+| `REFRESH_TOKEN_EXPIRED` | 401 | `rotateRefreshToken` |
+| `REFRESH_NOT_ENABLED` | 501 | `rotateRefreshToken` (misconfiguration) |
 
 ## Quick start
 
@@ -154,12 +207,13 @@ export class AuthController {
 }
 ```
 
-### 5. Apply guard globally (recommended)
+### 5. Apply guard and filter globally (recommended)
 
 ```ts
 // app.module.ts
 providers: [
-  { provide: APP_GUARD, useClass: JwtAuthGuard },
+  { provide: APP_GUARD,  useClass: JwtAuthGuard },
+  { provide: APP_FILTER, useClass: AuthExceptionFilter },
 ]
 // Then use @Public() on open endpoints instead of @UseGuards everywhere.
 ```
@@ -202,6 +256,26 @@ import * as cookieParser from 'cookie-parser';
 app.use(cookieParser());
 ```
 
+### Swapping the logger
+
+By default informational messages are written to `console.log`. To use NestJS
+structured logging:
+
+```ts
+import { Logger } from '@nestjs/common';
+import type { ILogger } from '@odysseon/auth';
+
+@Injectable()
+export class NestJsLogger implements ILogger {
+  private readonly l = new Logger('AuthService');
+  log(message: string)                     { this.l.log(message); }
+  error(message: string, ctx?: unknown)    { this.l.error(message, ctx); }
+}
+
+// In AuthModule.forRootAsync():
+logger: NestJsLogger
+```
+
 ## Testing
 
 Every external dependency is behind a port — mock the token, not the library:
@@ -214,6 +288,8 @@ const module = await Test.createTestingModule({ ... })
   .useValue({ init: jest.fn(), sign: jest.fn().mockResolvedValue('token'), verify: jest.fn() })
   .overrideProvider(PORTS.TOKEN_EXTRACTOR)
   .useValue({ extract: jest.fn().mockReturnValue('mock-token') })
+  .overrideProvider(PORTS.LOGGER)
+  .useValue({ log: jest.fn(), error: jest.fn() })
   .compile();
 ```
 
@@ -224,7 +300,11 @@ No real crypto runs in tests. Blazing fast, zero flakiness.
 | Export | Description |
 |---|---|
 | `AuthModule` | Root module — `forRootAsync()` |
+| `AuthModuleAsyncOptions` | NestJS wiring type for `forRootAsync()` |
 | `AuthService` | All use-case methods |
+| `AuthError` | Domain error class thrown by `AuthService` |
+| `AuthErrorCode` | Typed error code constants |
+| `AuthExceptionFilter` | NestJS filter — maps `AuthError` codes to HTTP responses |
 | `JwtAuthGuard` | Protect routes; respects `@Public()` |
 | `GoogleOAuthGuard` | Initiate / handle Google OAuth |
 | `@CurrentUser()` | Extract `RequestUser` from request |
@@ -235,10 +315,12 @@ No real crypto runs in tests. Blazing fast, zero flakiness.
 | `BearerTokenExtractor` | Default extractor — `Authorization: Bearer` header |
 | `CookieTokenExtractor` | Extractor — named HTTP cookie |
 | `QueryParamTokenExtractor` | Extractor — URL query parameter |
+| `ConsoleLogger` | Default logger adapter (console.log / console.error, zero deps) |
 | `IJwtSigner` | Port — implement to swap JWT library |
 | `IPasswordHasher` | Port — implement to swap password hasher |
 | `ITokenHasher` | Port — implement to swap token hasher |
 | `ITokenExtractor` | Port — implement to swap token extraction |
+| `ILogger` | Port — implement to swap logger |
 | `IUserRepository` | Port — implement in your infra layer |
 | `IRefreshTokenRepository` | Port — implement in your infra layer |
 | `PORTS`, `AUTH_CAPABILITIES` | DI tokens for testing overrides |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@odysseon/auth",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Identity-only authentication module for NestJS — hexagonal architecture, ORM-agnostic",
   "author": "Odysseon",
   "license": "MIT",

--- a/src/README.md
+++ b/src/README.md
@@ -9,33 +9,37 @@ src/
 ├── index.ts              ← Public API surface (only import from here)
 │
 ├── interfaces/           ← Ports & domain types (zero framework or library deps)
-│   └── ports/            ← Internal ports: IJwtSigner, IPasswordHasher, ITokenHasher, ITokenExtractor
+│   └── ports/            ← IJwtSigner, IPasswordHasher, ITokenHasher, ITokenExtractor, ILogger
+├── errors/               ← AuthError + AuthErrorCode (zero deps — thrown by AuthService)
 ├── constants/            ← DI injection tokens (Symbols)
-├── adapters/             ← Default implementations of the four internal ports
+├── adapters/             ← Default implementations of the five internal ports
 ├── core/                 ← AuthModule + AuthService (use-case layer)
+├── filters/              ← AuthExceptionFilter (NestJS HTTP adapter for AuthError)
 ├── strategies/           ← Passport strategies (JWT, Google)
 ├── guards/               ← JwtAuthGuard, GoogleOAuthGuard
-└── decorators/           ← @CurrentUser(), @Public()
+├── decorators/           ← @CurrentUser(), @Public()
+└── examples/             ← Reference-only code (excluded from dist/)
 ```
 
 ## Dependency direction
 
 ```
 interfaces/ports/  (contracts — zero deps)
+errors/            (AuthError — zero deps)
        ↑
-  adapters/        (wrap external libs: jose, argon2, node:crypto, and header/cookie/query parsing)
+  adapters/        (wrap external libs: jose, argon2, node:crypto, console)
        ↑
    core/ ──────────────────────────────────────── strategies/
 (AuthModule wires                           (inject ports by token,
  ports → adapters,                           never libs directly)
  AuthService uses ports)
        ↑
-   guards/ / decorators/
+   filters/ / guards/ / decorators/
 ```
 
-**Nothing above `interfaces/` is imported by anything below it.**
-`AuthService` and `JwtStrategy` depend only on port interfaces — never on
-`jose`, `argon2`, or any other external library directly.
+**Nothing above `interfaces/` or `errors/` is imported by anything below it.**
+`AuthService` throws `AuthError` (from `errors/`) — never NestJS HTTP exceptions.
+`AuthExceptionFilter` (in `filters/`) is the only place that maps `AuthError` to HTTP.
 
 ## Swapping an external library
 
@@ -48,6 +52,7 @@ AuthModule.forRootAsync({
   passwordHasher: BcryptPasswordHasher, // replaces Argon2PasswordHasher (argon2)
   tokenHasher:    KmsTokenHasher,       // replaces CryptoTokenHasher (node:crypto)
   tokenExtractor: new CookieTokenExtractor('access_token'), // replaces BearerTokenExtractor
+  logger:         NestJsLogger,         // replaces ConsoleLogger
   // ... rest of options
 })
 ```
@@ -61,4 +66,5 @@ No other files change.
 3. Implement the strategy in `strategies/`.
 4. Wire the token and strategy in `core/auth.module.ts`.
 5. Add the use-case method(s) to `core/auth.service.ts`.
-6. Re-export from `src/index.ts`.
+6. Add any new `AuthErrorCode` values to `errors/auth-error.ts`.
+7. Re-export from `src/index.ts`.

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -1,6 +1,6 @@
 # src/adapters/
 
-Default implementations of the four internal ports. Every adapter in this
+Default implementations of the five internal ports. Every adapter in this
 directory is **swappable** — pass a replacement class (or instance) to
 `AuthModule.forRootAsync()` and the rest of the module is completely unaffected.
 
@@ -81,6 +81,9 @@ export class KmsTokenHasher implements ITokenHasher {
 Reads the JWT from the `Authorization: Bearer <token>` header. This is
 `AuthModule`'s default — no configuration required for standard API setups.
 
+Handles array-valued headers (some proxies forward repeated headers as arrays)
+and guards against empty tokens (`"Bearer "` returns `null`).
+
 **To swap:** Use `CookieTokenExtractor`, `QueryParamTokenExtractor`, or
 implement `ITokenExtractor` and pass it as `tokenExtractor:`.
 
@@ -116,12 +119,37 @@ most HTTP servers and proxies.
 
 ---
 
+### `ConsoleLogger` → `ILogger`  *(default)*
+
+Writes informational messages to `console.log` and errors to `console.error`.
+
+**Zero external dependencies** — no `@nestjs/common`, no logging framework.
+Works in plain Node.js, NestJS, Fastify, Lambda, or any other runtime.
+
+**To swap:** Implement `ILogger` and pass `logger: YourClass`.
+
+```ts
+// nestjs-logger.adapter.ts
+import { Logger } from '@nestjs/common';
+
+@Injectable()
+export class NestJsLogger implements ILogger {
+  private readonly l = new Logger('AuthService');
+  log(message: string)                  { this.l.log(message); }
+  error(message: string, ctx?: unknown) { this.l.error(message, ctx); }
+}
+
+// AuthModule.forRootAsync({ logger: NestJsLogger, ... })
+```
+
+---
+
 ## Dependency direction
 
 ```
 interfaces/ports/  (contracts — no deps)
       ↑
-adapters/          (default implementations — depend on external libs)
+adapters/          (default implementations — depend on external libs or nothing)
       ↑
 core/              (AuthModule wires ports → adapters via DI tokens)
 ```

--- a/src/adapters/console-logger.adapter.ts
+++ b/src/adapters/console-logger.adapter.ts
@@ -1,4 +1,3 @@
-import { Injectable } from '@nestjs/common';
 import type { ILogger } from '../interfaces/ports/logger.port';
 
 /**
@@ -8,7 +7,6 @@ import type { ILogger } from '../interfaces/ports/logger.port';
  * Swap this by implementing `ILogger` and passing
  * `logger: YourClass` to `AuthModule.forRootAsync()`.
  */
-@Injectable()
 export class ConsoleLogger implements ILogger {
   log(message: string): void {
     console.log(`[AuthService] ${message}`);

--- a/src/adapters/console-logger.adapter.ts
+++ b/src/adapters/console-logger.adapter.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import type { ILogger } from '../interfaces/ports/logger.port';
+
+/**
+ * Default `ILogger` adapter — writes to stdout/stderr via `console`.
+ * No external dependencies beyond Node.js itself.
+ *
+ * Swap this by implementing `ILogger` and passing
+ * `logger: YourClass` to `AuthModule.forRootAsync()`.
+ */
+@Injectable()
+export class ConsoleLogger implements ILogger {
+  log(message: string): void {
+    console.log(`[AuthService] ${message}`);
+  }
+
+  error(message: string, context?: unknown): void {
+    console.error(`[AuthService] ${message}`, context ?? '');
+  }
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -4,3 +4,4 @@ export * from './jose-jwt-signer.adapter';
 export * from './bearer-token-extractor.adapter';
 export * from './cookie-token-extractor.adapter';
 export * from './query-param-token-extractor.adapter';
+export * from './console-logger.adapter';

--- a/src/constants/README.md
+++ b/src/constants/README.md
@@ -38,6 +38,7 @@ the whole config object, so they stay narrowly scoped.
 | `PORTS.PASSWORD_HASHER` | `IPasswordHasher` | `Argon2PasswordHasher` | `passwordHasher: YourClass` |
 | `PORTS.TOKEN_HASHER` | `ITokenHasher` | `CryptoTokenHasher` | `tokenHasher: YourClass` |
 | `PORTS.TOKEN_EXTRACTOR` | `ITokenExtractor` | `BearerTokenExtractor` | `tokenExtractor: YourClass` |
+| `PORTS.LOGGER` | `ILogger` | `ConsoleLogger` | `logger: YourClass` |
 
 ## Testing overrides
 
@@ -50,5 +51,9 @@ the whole config object, so they stay narrowly scoped.
 {
   provide: PORTS.TOKEN_EXTRACTOR,
   useValue: { extract: jest.fn().mockReturnValue('mock-token') },
+}
+{
+  provide: PORTS.LOGGER,
+  useValue: { log: jest.fn(), error: jest.fn() },
 }
 ```

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -28,4 +28,6 @@ export const PORTS = Object.freeze({
   TOKEN_HASHER: Symbol('TOKEN_HASHER'),
   /** ITokenExtractor — defaults to BearerTokenExtractor (Authorization header). */
   TOKEN_EXTRACTOR: Symbol('TOKEN_EXTRACTOR'),
+  /** ILogger — defaults to ConsoleLogger (console.log / console.error). */
+  LOGGER: Symbol('LOGGER'),
 });

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -11,6 +11,8 @@ The dynamic root module. Consumers register it once via `forRootAsync()`.
 Responsibilities:
 - Accept configuration, repository classes, and capability flags.
 - Register all internal providers with the correct DI tokens.
+- Run `AuthService.init()` at startup via the internal `AuthInitializer` class
+  (which implements `OnModuleInit` so `AuthService` itself does not need to).
 - Conditionally wire Google strategy/guard only when `'google'` is listed
   in `enabledCapabilities`.
 - Export `AuthService`, `JwtAuthGuard`, and (when enabled) `GoogleOAuthGuard`
@@ -22,8 +24,13 @@ Decorated `@Global()` — register it once at the app root.
 
 The **single orchestrator** for all authentication use-cases.
 
+`AuthService` is a plain class with no NestJS lifecycle coupling. It throws
+`AuthError` with typed `AuthErrorCode` values — never HTTP exceptions. The
+`AuthExceptionFilter` in `src/filters/` maps those codes to HTTP responses.
+
 | Method | Capability | Description |
 |---|---|---|
+| `init()` | — | Validate config and initialise the JWT signer. Call once at startup. |
 | `loginWithCredentials(input)` | credentials | Verify email + password, issue tokens |
 | `register(input)` | credentials | Create user, hash password, issue tokens |
 | `handleGoogleCallback(requestUser)` | google | Issue tokens after Passport sets `req.user` |
@@ -31,13 +38,14 @@ The **single orchestrator** for all authentication use-cases.
 | `logout(userId)` | refresh tokens | Revoke all refresh tokens for a user |
 | `changePassword(input)` | credentials | Change password (requires current password) |
 | `setPassword(input)` | credentials | Force-set password (admin / reset flow) |
-| `verifyAccessToken(token)` | any | Verify a Bearer token (for custom guards) |
+| `verifyAccessToken(token)` | any | Verify a token (for custom guards) |
 
 ### What `AuthService` does NOT do
 
-- No authorisation checks (roles, permissions, policies).
-- No email delivery.
-- No session management.
+- Authorisation checks (roles, permissions, policies).
+- Email delivery.
+- Session management.
+- HTTP response formatting — that is `AuthExceptionFilter`'s job.
 
 ### Token issuance internals
 
@@ -47,5 +55,5 @@ One-time-use is enforced by the atomic `consumeByTokenHash` method on
 `IRefreshTokenRepository` — a single `DELETE … RETURNING *` prevents two
 concurrent rotation requests from both succeeding with the same token.
 
-Keys are imported from `JwtConfig` once at `onModuleInit` and reused,
+Keys are imported from `JwtConfig` once in `init()` and reused,
 avoiding per-request key parsing overhead.

--- a/src/core/auth.module.ts
+++ b/src/core/auth.module.ts
@@ -1,4 +1,13 @@
-import { DynamicModule, Global, Module, Provider, Type } from '@nestjs/common';
+import {
+  DynamicModule,
+  Global,
+  Module,
+  Provider,
+  Type,
+  OnModuleInit,
+  Inject,
+} from '@nestjs/common';
+import type { ModuleMetadata, FactoryProvider } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { AUTH_CONFIG, AUTH_CAPABILITIES, PORTS } from '../constants';
 import { AuthService } from './auth.service';
@@ -10,59 +19,135 @@ import { JoseJwtSigner } from '../adapters/jose-jwt-signer.adapter';
 import { Argon2PasswordHasher } from '../adapters/argon2-password-hasher.adapter';
 import { CryptoTokenHasher } from '../adapters/crypto-token-hasher.adapter';
 import { BearerTokenExtractor } from '../adapters/bearer-token-extractor.adapter';
+import { ConsoleLogger } from '../adapters/console-logger.adapter';
 import type { IJwtSigner } from '../interfaces/ports/jwt-signer.port';
 import type { IPasswordHasher } from '../interfaces/ports/password-hasher.port';
 import type { ITokenHasher } from '../interfaces/ports/token-hasher.port';
 import type { ITokenExtractor } from '../interfaces/ports/token-extractor.port';
+import type { ILogger } from '../interfaces/ports/logger.port';
+import type { AuthModuleConfig } from '../interfaces/configuration/auth-module-config.interface';
+import type { AuthUser, IUserRepository } from '../interfaces/user-model';
 import type {
-  AuthModuleAsyncOptions,
-  AuthModuleConfig,
-  AuthUser,
-} from '../interfaces';
-import type { IRefreshToken } from '../interfaces/refresh-token';
+  IRefreshToken,
+  IRefreshTokenRepository,
+} from '../interfaces/refresh-token';
 import { validateJwtConfig } from '../interfaces/configuration/jwt-config.interface';
 
+// ── NestJS wiring types (live here, not in the interface layer) ───────────
+
 /**
- * Extend the async options with optional adapter overrides.
- * Each defaults to the bundled adapter if omitted.
+ * Async registration options for `AuthModule.forRootAsync()`.
+ *
+ * Mirrors the standard NestJS `*AsyncOptions` pattern so consumers can
+ * inject `ConfigService` or any other provider into `useFactory`.
+ *
+ * This type lives alongside `forRootAsync()` in the module file — it is a
+ * NestJS wiring concern, not a domain contract, and therefore does not belong
+ * in `interfaces/configuration/`.
+ */
+export interface AuthModuleAsyncOptions<
+  User extends Partial<AuthUser> = Partial<AuthUser>,
+  RT extends IRefreshToken = IRefreshToken,
+>
+  extends
+    Pick<ModuleMetadata, 'imports'>,
+    Pick<FactoryProvider<AuthModuleConfig>, 'useFactory' | 'inject'> {
+  /**
+   * Class that implements `IUserRepository` (or `IGoogleUserRepository`
+   * when google is enabled). Registered as a provider so it can receive
+   * its own injected dependencies.
+   */
+  userRepository: Type<IUserRepository<User>>;
+
+  /**
+   * Class that implements `IRefreshTokenRepository`.
+   * When omitted, refresh-token rotation is disabled and
+   * `AuthService.rotateRefreshToken()` will throw `AuthError` with
+   * code `REFRESH_NOT_ENABLED`.
+   */
+  refreshTokenRepository?: Type<IRefreshTokenRepository<RT>>;
+
+  /**
+   * Explicitly opt in to each authentication capability you need.
+   * Only the listed capabilities will have their providers registered.
+   */
+  enabledCapabilities: Array<'credentials' | 'google'>;
+}
+
+/**
+ * Optional adapter overrides — each defaults to the bundled implementation.
  */
 export interface AuthModuleAdapterOverrides {
   /**
    * Custom JWT signer adapter.
-   * Default: `JoseJwtSigner` (jose library — Web Crypto, zero deps).
-   * Swap to: jsonwebtoken, fast-jwt, or any `IJwtSigner` implementation.
+   * Default: `JoseJwtSigner` (jose — Web Crypto, zero deps).
    */
   jwtSigner?: Type<IJwtSigner>;
 
   /**
    * Custom password hasher adapter.
    * Default: `Argon2PasswordHasher` (argon2id — OWASP recommended).
-   * Swap to: bcrypt, scrypt, PBKDF2, or any `IPasswordHasher` implementation.
    */
   passwordHasher?: Type<IPasswordHasher>;
 
   /**
    * Custom token hasher adapter.
-   * Default: `CryptoTokenHasher` (Node built-in crypto — no extra deps).
-   * Swap to: a KMS-backed, HSM-backed, or any `ITokenHasher` implementation.
+   * Default: `CryptoTokenHasher` (node:crypto — no extra deps).
    */
   tokenHasher?: Type<ITokenHasher>;
 
   /**
    * Custom token extractor adapter.
-   * Default: `BearerTokenExtractor` — reads `Authorization: Bearer <token>`.
-   * Swap to: `CookieTokenExtractor`, `QueryParamTokenExtractor`, or any
-   * `ITokenExtractor` implementation to change where JwtStrategy looks for
-   * the access token on incoming requests.
+   * Default: `BearerTokenExtractor` (`Authorization: Bearer <token>`).
+   * Accepts a class or a pre-built instance for extractors that require
+   * constructor arguments (e.g. `new CookieTokenExtractor('access_token')`).
+   */
+  tokenExtractor?: Type<ITokenExtractor> | ITokenExtractor;
+
+  /**
+   * Custom logger adapter.
+   * Default: `ConsoleLogger` (console.log / console.error).
+   * Swap to get NestJS structured logging, Pino, Winston, etc.
    *
    * @example
    * ```ts
-   * // Read from a cookie named 'access_token' instead of the header:
-   * tokenExtractor: new CookieTokenExtractor('access_token')
+   * // NestJS Logger
+   * @Injectable()
+   * class NestJsLogger implements ILogger {
+   *   private readonly l = new Logger('AuthService');
+   *   log(msg: string)               { this.l.log(msg); }
+   *   error(msg: string, ctx?: unknown) { this.l.error(msg, ctx); }
+   * }
+   * // AuthModule.forRootAsync({ logger: NestJsLogger, ... })
    * ```
    */
-  tokenExtractor?: Type<ITokenExtractor> | ITokenExtractor;
+  logger?: Type<ILogger>;
 }
+
+// ── Internal OnModuleInit wrapper ─────────────────────────────────────────
+
+/**
+ * Internal NestJS lifecycle hook that calls `AuthService.init()` at startup.
+ *
+ * `AuthService` itself does not implement `OnModuleInit` — it is a plain
+ * class with no framework lifecycle coupling. This wrapper lives in the
+ * module file (the NestJS adapter layer) and is the only place that ties
+ * the startup sequence to NestJS.
+ */
+@Global()
+@Module({})
+class AuthInitializer implements OnModuleInit {
+  constructor(
+    @Inject(AuthService)
+    private readonly authService: AuthService,
+  ) {}
+
+  async onModuleInit(): Promise<void> {
+    await this.authService.init();
+  }
+}
+
+// ── AuthModule ────────────────────────────────────────────────────────────
 
 /**
  * The root authentication module.
@@ -72,21 +157,31 @@ export interface AuthModuleAdapterOverrides {
  * `AuthService`, `JwtAuthGuard`, and `GoogleOAuthGuard` without re-importing.
  *
  * ### Default adapters (all swappable)
- * | Port                | Default adapter          | Swap via                    |
- * |---------------------|--------------------------|-----------------------------|
- * | `IJwtSigner`        | `JoseJwtSigner`          | `jwtSigner:`                |
- * | `IPasswordHasher`   | `Argon2PasswordHasher`   | `passwordHasher:`           |
- * | `ITokenHasher`      | `CryptoTokenHasher`      | `tokenHasher:`              |
- * | `ITokenExtractor`   | `BearerTokenExtractor`   | `tokenExtractor:`           |
+ * | Port               | Default adapter        | Swap via            |
+ * |--------------------|------------------------|---------------------|
+ * | `IJwtSigner`       | `JoseJwtSigner`        | `jwtSigner:`        |
+ * | `IPasswordHasher`  | `Argon2PasswordHasher` | `passwordHasher:`   |
+ * | `ITokenHasher`     | `CryptoTokenHasher`    | `tokenHasher:`      |
+ * | `ITokenExtractor`  | `BearerTokenExtractor` | `tokenExtractor:`   |
+ * | `ILogger`          | `ConsoleLogger`        | `logger:`           |
+ *
+ * ### Error handling
+ * `AuthService` throws `AuthError` with typed `AuthErrorCode` values.
+ * Register `AuthExceptionFilter` to map these to HTTP responses:
+ *
+ * ```ts
+ * // app.module.ts
+ * providers: [{ provide: APP_FILTER, useClass: AuthExceptionFilter }]
+ * ```
  *
  * @example
  * ```ts
  * AuthModule.forRootAsync({
- *   imports: [ConfigModule],
- *   inject:  [ConfigService],
+ *   imports:  [ConfigModule],
+ *   inject:   [ConfigService],
  *   useFactory: (cfg: ConfigService) => ({
  *     jwt: {
- *       type: 'asymmetric',
+ *       type:         'asymmetric',
  *       privateKey:   cfg.get('JWT_PRIVATE_KEY'),
  *       publicKey:    cfg.get('JWT_PUBLIC_KEY'),
  *       accessToken:  { expiresIn: '15m', algorithm: 'ES256' },
@@ -101,12 +196,6 @@ export interface AuthModuleAdapterOverrides {
  *   userRepository:         UserRepository,
  *   refreshTokenRepository: RefreshTokenRepository,
  *   enabledCapabilities:    ['credentials', 'google'],
- *
- *   // Optional — swap any default adapter:
- *   // jwtSigner:      JsonwebtokenSigner,
- *   // passwordHasher: BcryptPasswordHasher,
- *   // tokenHasher:    KmsTokenHasher,
- *   // tokenExtractor: new CookieTokenExtractor('access_token'),
  * })
  * ```
  */
@@ -119,7 +208,7 @@ export class AuthModule {
   >(
     options: AuthModuleAsyncOptions<User, RT> & AuthModuleAdapterOverrides,
   ): DynamicModule {
-    // ── Config ─────────────────────────────────────────────────────────────
+    // ── Config ───────────────────────────────────────────────────────────
     const configProvider: Provider = {
       provide: AUTH_CONFIG,
       useFactory: options.useFactory,
@@ -144,32 +233,27 @@ export class AuthModule {
       inject: [AUTH_CONFIG],
     };
 
-    // ── Caller-supplied repository ports ───────────────────────────────────
+    // ── Caller-supplied repository ────────────────────────────────────────
     const userRepoProvider: Provider = {
       provide: PORTS.USER_REPOSITORY,
       useClass: options.userRepository,
     };
 
-    // ── Adapter ports — defaults with opt-in overrides ─────────────────────
-    const jwtSignerClass = options.jwtSigner ?? JoseJwtSigner;
-    const passwordHasherClass = options.passwordHasher ?? Argon2PasswordHasher;
-    const tokenHasherClass = options.tokenHasher ?? CryptoTokenHasher;
-
+    // ── Swappable adapter ports ───────────────────────────────────────────
     const jwtSignerProvider: Provider = {
       provide: PORTS.JWT_SIGNER,
-      useClass: jwtSignerClass,
+      useClass: options.jwtSigner ?? JoseJwtSigner,
     };
     const passwordHasherProvider: Provider = {
       provide: PORTS.PASSWORD_HASHER,
-      useClass: passwordHasherClass,
+      useClass: options.passwordHasher ?? Argon2PasswordHasher,
     };
     const tokenHasherProvider: Provider = {
       provide: PORTS.TOKEN_HASHER,
-      useClass: tokenHasherClass,
+      useClass: options.tokenHasher ?? CryptoTokenHasher,
     };
 
-    // tokenExtractor accepts either a class (registered via useClass so it
-    // can receive its own injected deps) or a pre-built instance (useValue).
+    // tokenExtractor accepts a class or a pre-built instance.
     const tokenExtractorProvider: Provider =
       options.tokenExtractor == null
         ? { provide: PORTS.TOKEN_EXTRACTOR, useClass: BearerTokenExtractor }
@@ -180,7 +264,12 @@ export class AuthModule {
               useValue: options.tokenExtractor,
             };
 
-    // ── Assemble ───────────────────────────────────────────────────────────
+    const loggerProvider: Provider = {
+      provide: PORTS.LOGGER,
+      useClass: options.logger ?? ConsoleLogger,
+    };
+
+    // ── Assemble ─────────────────────────────────────────────────────────
     const providers: Provider[] = [
       configProvider,
       jwtCapabilityProvider,
@@ -190,7 +279,9 @@ export class AuthModule {
       passwordHasherProvider,
       tokenHasherProvider,
       tokenExtractorProvider,
+      loggerProvider,
       AuthService,
+      AuthInitializer,
       JwtStrategy,
       JwtAuthGuard,
     ];
@@ -198,18 +289,15 @@ export class AuthModule {
     const moduleExports: Array<string | symbol | Provider> = [
       AuthService,
       JwtAuthGuard,
-      // Expose adapter tokens so advanced consumers can inject them directly.
       PORTS.JWT_SIGNER,
       PORTS.PASSWORD_HASHER,
       PORTS.TOKEN_HASHER,
       PORTS.TOKEN_EXTRACTOR,
+      PORTS.LOGGER,
     ];
 
     // ── Refresh token repository (optional) ───────────────────────────────
     if (options.refreshTokenRepository) {
-      // Validate that jwt.refreshToken config is also present; a repository
-      // without the config block would cause a silent runtime failure when
-      // AuthService tries to read rtConfig.expiresIn.
       const configValidationProvider: Provider = {
         provide: 'REFRESH_TOKEN_CONFIG_GUARD',
         useFactory: (cfg: AuthModuleConfig) => {

--- a/src/core/auth.service.spec.ts
+++ b/src/core/auth.service.spec.ts
@@ -1,15 +1,11 @@
 import { Test } from '@nestjs/testing';
-import {
-  UnauthorizedException,
-  ConflictException,
-  BadRequestException,
-  NotFoundException,
-} from '@nestjs/common';
 import { AuthService } from './auth.service';
+import { AuthError, AuthErrorCode } from '../errors/auth-error';
 import { AUTH_CAPABILITIES, PORTS } from '../constants';
 import type { IJwtSigner } from '../interfaces/ports/jwt-signer.port';
 import type { IPasswordHasher } from '../interfaces/ports/password-hasher.port';
 import type { ITokenHasher } from '../interfaces/ports/token-hasher.port';
+import type { ILogger } from '../interfaces/ports/logger.port';
 import type { IUserRepository } from '../interfaces/user-model/user-repository.interface';
 import type { IRefreshTokenRepository } from '../interfaces/refresh-token/refresh-token.interface';
 import type { JwtConfig } from '../interfaces/configuration/jwt-config.interface';
@@ -52,6 +48,13 @@ function makeMockTokenHasher(): jest.Mocked<ITokenHasher> {
   return {
     hash: jest.fn().mockReturnValue('hashed-token'),
     generate: jest.fn().mockReturnValue('plain-token'),
+  };
+}
+
+function makeMockLogger(): jest.Mocked<ILogger> {
+  return {
+    log: jest.fn(),
+    error: jest.fn(),
   };
 }
 
@@ -105,6 +108,7 @@ async function buildService(
     ...overrides.passwordHasher,
   };
   const tokenHasher = { ...makeMockTokenHasher(), ...overrides.tokenHasher };
+  const logger = makeMockLogger();
   const userRepo = { ...makeMockUserRepo(), ...overrides.userRepo };
   const refreshTokenRepo =
     overrides.refreshTokenRepo === null
@@ -117,6 +121,7 @@ async function buildService(
     { provide: PORTS.JWT_SIGNER, useValue: jwtSigner },
     { provide: PORTS.PASSWORD_HASHER, useValue: passwordHasher },
     { provide: PORTS.TOKEN_HASHER, useValue: tokenHasher },
+    { provide: PORTS.LOGGER, useValue: logger },
     { provide: PORTS.USER_REPOSITORY, useValue: userRepo },
     ...(refreshTokenRepo !== null
       ? [
@@ -130,24 +135,36 @@ async function buildService(
 
   const moduleRef = await Test.createTestingModule({ providers }).compile();
   const service = moduleRef.get(AuthService);
-  await service.onModuleInit();
+  await service.init();
 
   return {
     service,
     jwtSigner,
     passwordHasher,
     tokenHasher,
+    logger,
     userRepo,
     refreshTokenRepo,
   };
 }
 
+// helper — asserts the thrown error is an AuthError with the expected code
+async function expectAuthError(
+  promise: Promise<unknown>,
+  code: AuthErrorCode,
+): Promise<void> {
+  await expect(promise).rejects.toThrow(AuthError);
+  await promise.catch((e: AuthError) => {
+    expect(e.code).toBe(code);
+  });
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('AuthService', () => {
-  // ── onModuleInit ──────────────────────────────────────────────────────────
+  // ── init ──────────────────────────────────────────────────────────────────
 
-  describe('onModuleInit', () => {
+  describe('init', () => {
     it('calls jwtSigner.init with the jwt config', async () => {
       const { jwtSigner } = await buildService();
       expect(jwtSigner.init).toHaveBeenCalledWith(JWT_CONFIG);
@@ -198,14 +215,15 @@ describe('AuthService', () => {
       expect(result.user.userId).toBe('user-1');
     });
 
-    it('throws ConflictException when email already exists', async () => {
+    it('throws AuthError EMAIL_ALREADY_EXISTS when email already exists', async () => {
       const { service } = await buildService({
         userRepo: { findByEmail: jest.fn().mockResolvedValue(MOCK_USER) },
       });
 
-      await expect(
+      await expectAuthError(
         service.register({ email: 'test@example.com', password: 'secret' }),
-      ).rejects.toThrow(ConflictException);
+        AuthErrorCode.EMAIL_ALREADY_EXISTS,
+      );
     });
 
     it('returns only accessToken when refresh tokens are not configured', async () => {
@@ -241,7 +259,6 @@ describe('AuthService', () => {
       const expiresAt: Date = callArgs[0].expiresAt;
       const ttlSeconds = (expiresAt.getTime() - before) / 1000;
 
-      // 2 weeks = 1_209_600 seconds. Allow a few seconds of test latency.
       expect(ttlSeconds).toBeGreaterThan(1_209_594);
       expect(expiresAt.getTime()).toBeLessThanOrEqual(
         after + 2 * 604800 * 1000 + 1000,
@@ -268,31 +285,33 @@ describe('AuthService', () => {
       );
     });
 
-    it('throws UnauthorizedException for unknown email', async () => {
+    it('throws AuthError INVALID_CREDENTIALS for unknown email', async () => {
       const { service } = await buildService({
         userRepo: { findByEmail: jest.fn().mockResolvedValue(null) },
       });
 
-      await expect(
+      await expectAuthError(
         service.loginWithCredentials({ email: 'nobody@x.com', password: 'pw' }),
-      ).rejects.toThrow(UnauthorizedException);
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
 
-    it('throws UnauthorizedException for wrong password', async () => {
+    it('throws AuthError INVALID_CREDENTIALS for wrong password', async () => {
       const { service } = await buildService({
         userRepo: { findByEmail: jest.fn().mockResolvedValue(MOCK_USER) },
         passwordHasher: { verify: jest.fn().mockResolvedValue(false) },
       });
 
-      await expect(
+      await expectAuthError(
         service.loginWithCredentials({
           email: 'test@example.com',
           password: 'wrong',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
 
-    it('throws UnauthorizedException for OAuth-only accounts', async () => {
+    it('throws AuthError INVALID_CREDENTIALS for OAuth-only accounts', async () => {
       const { service } = await buildService({
         userRepo: {
           findByEmail: jest
@@ -301,12 +320,13 @@ describe('AuthService', () => {
         },
       });
 
-      await expect(
+      await expectAuthError(
         service.loginWithCredentials({
           email: 'test@example.com',
           password: 'pw',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
   });
 
@@ -324,14 +344,15 @@ describe('AuthService', () => {
       expect(result.user.userId).toBe('user-1');
     });
 
-    it('throws UnauthorizedException if user not found', async () => {
+    it('throws AuthError OAUTH_USER_NOT_FOUND if user not found', async () => {
       const { service } = await buildService({
         userRepo: { findById: jest.fn().mockResolvedValue(null) },
       });
 
-      await expect(
+      await expectAuthError(
         service.handleGoogleCallback({ userId: 'ghost' }),
-      ).rejects.toThrow(UnauthorizedException);
+        AuthErrorCode.OAUTH_USER_NOT_FOUND,
+      );
     });
   });
 
@@ -365,19 +386,20 @@ describe('AuthService', () => {
       expect(result.refreshToken).toBe('plain-token');
     });
 
-    it('throws UnauthorizedException when consumeByTokenHash returns null (unknown or already-used token)', async () => {
+    it('throws AuthError REFRESH_TOKEN_INVALID when consumeByTokenHash returns null', async () => {
       const { service } = await buildService({
         refreshTokenRepo: {
           consumeByTokenHash: jest.fn().mockResolvedValue(null),
         },
       });
 
-      await expect(service.rotateRefreshToken('bad-token')).rejects.toThrow(
-        UnauthorizedException,
+      await expectAuthError(
+        service.rotateRefreshToken('bad-token'),
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
       );
     });
 
-    it('throws UnauthorizedException for an expired token (no extra delete needed)', async () => {
+    it('throws AuthError REFRESH_TOKEN_EXPIRED for an expired token', async () => {
       const { service } = await buildService({
         refreshTokenRepo: {
           consumeByTokenHash: jest.fn().mockResolvedValue({
@@ -389,24 +411,27 @@ describe('AuthService', () => {
         },
       });
 
-      await expect(service.rotateRefreshToken('plain-token')).rejects.toThrow(
-        'expired',
+      await expectAuthError(
+        service.rotateRefreshToken('plain-token'),
+        AuthErrorCode.REFRESH_TOKEN_EXPIRED,
       );
     });
 
-    it('throws BadRequestException when refresh tokens are not configured', async () => {
+    it('throws AuthError REFRESH_NOT_ENABLED when refresh tokens are not configured', async () => {
       const { service } = await buildService({ refreshTokenRepo: null });
 
-      await expect(service.rotateRefreshToken('token')).rejects.toThrow(
-        BadRequestException,
+      await expectAuthError(
+        service.rotateRefreshToken('token'),
+        AuthErrorCode.REFRESH_NOT_ENABLED,
       );
     });
 
-    it('throws BadRequestException for empty token string', async () => {
+    it('throws AuthError REFRESH_TOKEN_INVALID for empty token string', async () => {
       const { service } = await buildService();
 
-      await expect(service.rotateRefreshToken('')).rejects.toThrow(
-        BadRequestException,
+      await expectAuthError(
+        service.rotateRefreshToken(''),
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
       );
     });
   });
@@ -440,39 +465,42 @@ describe('AuthService', () => {
       expect(result).toEqual({ userId: 'user-1' });
     });
 
-    it('throws UnauthorizedException when jwtSigner.verify throws', async () => {
+    it('throws AuthError REFRESH_TOKEN_INVALID when jwtSigner.verify throws', async () => {
       const { service } = await buildService({
         jwtSigner: {
           verify: jest.fn().mockRejectedValue(new Error('expired')),
         },
       });
 
-      await expect(service.verifyAccessToken('bad')).rejects.toThrow(
-        UnauthorizedException,
+      await expectAuthError(
+        service.verifyAccessToken('bad'),
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
       );
     });
 
-    it('throws UnauthorizedException when payload type is not "access"', async () => {
+    it('throws AuthError REFRESH_TOKEN_INVALID when payload type is not "access"', async () => {
       const { service } = await buildService({
         jwtSigner: {
           verify: jest.fn().mockResolvedValue({ sub: 'u', type: 'refresh' }),
         },
       });
 
-      await expect(service.verifyAccessToken('refresh-token')).rejects.toThrow(
-        UnauthorizedException,
+      await expectAuthError(
+        service.verifyAccessToken('refresh-token'),
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
       );
     });
 
-    it('throws UnauthorizedException when sub is missing', async () => {
+    it('throws AuthError REFRESH_TOKEN_INVALID when sub is missing', async () => {
       const { service } = await buildService({
         jwtSigner: {
           verify: jest.fn().mockResolvedValue({ sub: '', type: 'access' }),
         },
       });
 
-      await expect(service.verifyAccessToken('token')).rejects.toThrow(
-        UnauthorizedException,
+      await expectAuthError(
+        service.verifyAccessToken('token'),
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
       );
     });
   });
@@ -503,49 +531,52 @@ describe('AuthService', () => {
       );
     });
 
-    it('throws NotFoundException when user does not exist', async () => {
+    it('throws AuthError USER_NOT_FOUND when user does not exist', async () => {
       const { service } = await buildService({
         userRepo: { findById: jest.fn().mockResolvedValue(null) },
       });
 
-      await expect(
+      await expectAuthError(
         service.changePassword({
           userId: 'ghost',
           currentPassword: 'old',
           newPassword: 'new',
         }),
-      ).rejects.toThrow(NotFoundException);
+        AuthErrorCode.USER_NOT_FOUND,
+      );
     });
 
-    it('throws UnauthorizedException when current password is wrong', async () => {
+    it('throws AuthError INVALID_CREDENTIALS when current password is wrong', async () => {
       const { service } = await buildService({
         passwordHasher: { verify: jest.fn().mockResolvedValue(false) },
       });
 
-      await expect(
+      await expectAuthError(
         service.changePassword({
           userId: 'user-1',
           currentPassword: 'wrong',
           newPassword: 'new',
         }),
-      ).rejects.toThrow(UnauthorizedException);
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
 
-    it('throws BadRequestException when new password equals current', async () => {
+    it('throws AuthError PASSWORD_SAME_AS_OLD when new password equals current', async () => {
       const { service } = await buildService({
         passwordHasher: { verify: jest.fn().mockResolvedValue(true) },
       });
 
-      await expect(
+      await expectAuthError(
         service.changePassword({
           userId: 'user-1',
           currentPassword: 'same',
           newPassword: 'same',
         }),
-      ).rejects.toThrow(BadRequestException);
+        AuthErrorCode.PASSWORD_SAME_AS_OLD,
+      );
     });
 
-    it('throws BadRequestException for OAuth-only accounts', async () => {
+    it('throws AuthError OAUTH_ACCOUNT_NO_PASSWORD for OAuth-only accounts', async () => {
       const { service } = await buildService({
         userRepo: {
           findById: jest
@@ -554,13 +585,14 @@ describe('AuthService', () => {
         },
       });
 
-      await expect(
+      await expectAuthError(
         service.changePassword({
           userId: 'user-1',
           currentPassword: 'old',
           newPassword: 'new',
         }),
-      ).rejects.toThrow(BadRequestException);
+        AuthErrorCode.OAUTH_ACCOUNT_NO_PASSWORD,
+      );
     });
   });
 
@@ -578,14 +610,15 @@ describe('AuthService', () => {
       );
     });
 
-    it('throws NotFoundException when user does not exist', async () => {
+    it('throws AuthError USER_NOT_FOUND when user does not exist', async () => {
       const { service } = await buildService({
         userRepo: { findById: jest.fn().mockResolvedValue(null) },
       });
 
-      await expect(
+      await expectAuthError(
         service.setPassword({ userId: 'ghost', newPassword: 'new' }),
-      ).rejects.toThrow(NotFoundException);
+        AuthErrorCode.USER_NOT_FOUND,
+      );
     });
   });
 });

--- a/src/core/auth.service.ts
+++ b/src/core/auth.service.ts
@@ -223,7 +223,7 @@ export class AuthService {
     const user = await this.userRepo.findById(stored.userId);
     if (!user?.id) {
       throw new AuthError(
-        AuthErrorCode.OAUTH_USER_NOT_FOUND,
+        AuthErrorCode.USER_NOT_FOUND,
         'User no longer exists',
       );
     }

--- a/src/core/auth.service.ts
+++ b/src/core/auth.service.ts
@@ -1,18 +1,9 @@
-import {
-  Injectable,
-  Inject,
-  Optional,
-  UnauthorizedException,
-  ConflictException,
-  BadRequestException,
-  NotFoundException,
-  Logger,
-  OnModuleInit,
-} from '@nestjs/common';
+import { Injectable, Inject, Optional } from '@nestjs/common';
 import { AUTH_CAPABILITIES, PORTS } from '../constants';
 import type { IJwtSigner } from '../interfaces/ports/jwt-signer.port';
 import type { IPasswordHasher } from '../interfaces/ports/password-hasher.port';
 import type { ITokenHasher } from '../interfaces/ports/token-hasher.port';
+import type { ILogger } from '../interfaces/ports/logger.port';
 import type {
   JwtConfig,
   AuthResponse,
@@ -27,6 +18,7 @@ import type {
   PasswordSetInput,
 } from '../interfaces';
 import { validateJwtConfig } from '../interfaces/configuration/jwt-config.interface';
+import { AuthError, AuthErrorCode } from '../errors/auth-error';
 
 function parseDurationToSeconds(value: string | number): number {
   if (typeof value === 'number') return value;
@@ -48,13 +40,26 @@ function parseDurationToSeconds(value: string | number): number {
 /**
  * The single use-case service for all authentication operations.
  *
- * All external library dependencies are injected through ports:
- * - `PORTS.JWT_SIGNER`      → `IJwtSigner`      (default: JoseJwtSigner)
- * - `PORTS.PASSWORD_HASHER` → `IPasswordHasher` (default: Argon2PasswordHasher)
- * - `PORTS.TOKEN_HASHER`    → `ITokenHasher`    (default: CryptoTokenHasher)
+ * ### Framework independence
+ * `AuthService` has no dependency on any HTTP framework. All external
+ * dependencies are injected through ports. It throws `AuthError` with typed
+ * `AuthErrorCode` values — never HTTP-specific exceptions. Framework adapters
+ * (e.g. `AuthExceptionFilter` for NestJS) map those codes to HTTP responses.
  *
- * Swap any of them by passing a different adapter class to `AuthModule.forRootAsync()`.
- * This service never imports a crypto or JWT library directly.
+ * This means `AuthService` can be used directly in:
+ * - NestJS (Express or Fastify) via `AuthModule`
+ * - Plain Express / Fastify without NestJS
+ * - Queue workers, Lambda functions, CLI tools, gRPC services
+ *
+ * ### Ports injected
+ * | Token                       | Port               | Default adapter        |
+ * |-----------------------------|--------------------|------------------------|
+ * | `PORTS.JWT_SIGNER`          | `IJwtSigner`       | `JoseJwtSigner`        |
+ * | `PORTS.PASSWORD_HASHER`     | `IPasswordHasher`  | `Argon2PasswordHasher` |
+ * | `PORTS.TOKEN_HASHER`        | `ITokenHasher`     | `CryptoTokenHasher`    |
+ * | `PORTS.LOGGER`              | `ILogger`          | `ConsoleLogger`        |
+ * | `PORTS.USER_REPOSITORY`     | `IUserRepository`  | consumer-supplied      |
+ * | `PORTS.REFRESH_TOKEN_REPOSITORY` | `IRefreshTokenRepository` | consumer-supplied (optional) |
  *
  * ### Operations
  * | Method                 | Capability  | Description                              |
@@ -64,7 +69,7 @@ function parseDurationToSeconds(value: string | number): number {
  * | `handleGoogleCallback` | google      | Issue tokens after Passport OAuth flow   |
  * | `rotateRefreshToken`   | refresh     | Atomic consume + re-issue (one-time use) |
  * | `logout`               | refresh     | Revoke all refresh tokens for a user     |
- * | `verifyAccessToken`    | any         | Verify a Bearer token (custom guards)    |
+ * | `verifyAccessToken`    | any         | Verify a token (for custom guards)       |
  * | `changePassword`       | credentials | Change password (requires current)       |
  * | `setPassword`          | credentials | Force-set password (admin / reset flow)  |
  *
@@ -72,11 +77,10 @@ function parseDurationToSeconds(value: string | number): number {
  * - Authorisation (roles, permissions, resource policies)
  * - Email delivery or verification
  * - Session management
+ * - HTTP response formatting
  */
 @Injectable()
-export class AuthService implements OnModuleInit {
-  private readonly logger = new Logger(AuthService.name);
-
+export class AuthService {
   constructor(
     @Inject(AUTH_CAPABILITIES.JWT)
     private readonly jwtConfig: JwtConfig,
@@ -90,6 +94,9 @@ export class AuthService implements OnModuleInit {
     @Inject(PORTS.TOKEN_HASHER)
     private readonly tokenHasher: ITokenHasher,
 
+    @Inject(PORTS.LOGGER)
+    private readonly logger: ILogger,
+
     @Inject(PORTS.USER_REPOSITORY)
     private readonly userRepo: IUserRepository<Partial<AuthUser>>,
 
@@ -98,11 +105,16 @@ export class AuthService implements OnModuleInit {
     private readonly refreshTokenRepo: IRefreshTokenRepository<IRefreshToken> | null,
   ) {}
 
-  async onModuleInit(): Promise<void> {
+  /**
+   * Validates config and initialises the JWT signer.
+   * Call this once at startup before serving any requests.
+   * `AuthModule` calls it automatically via `AuthInitializer`.
+   */
+  async init(): Promise<void> {
     validateJwtConfig(this.jwtConfig);
     await this.jwtSigner.init(this.jwtConfig);
     this.logger.log(
-      `AuthService ready — JWT type: ${this.jwtConfig.type}, ` +
+      `ready — JWT type: ${this.jwtConfig.type}, ` +
         `refresh tokens: ${this.refreshEnabled ? 'enabled' : 'disabled'}`,
     );
   }
@@ -112,10 +124,16 @@ export class AuthService implements OnModuleInit {
   async loginWithCredentials(input: LoginInput): Promise<AuthResponse> {
     const user = await this.userRepo.findByEmail(input.email);
 
-    if (!user?.id) throw new UnauthorizedException('Invalid credentials');
+    if (!user?.id) {
+      throw new AuthError(
+        AuthErrorCode.INVALID_CREDENTIALS,
+        'Invalid credentials',
+      );
+    }
 
     if (!('password' in user) || !user.password) {
-      throw new UnauthorizedException(
+      throw new AuthError(
+        AuthErrorCode.INVALID_CREDENTIALS,
         'This account was created via social login. Sign in with Google instead.',
       );
     }
@@ -124,7 +142,12 @@ export class AuthService implements OnModuleInit {
       input.password,
       user.password as string,
     );
-    if (!valid) throw new UnauthorizedException('Invalid credentials');
+    if (!valid) {
+      throw new AuthError(
+        AuthErrorCode.INVALID_CREDENTIALS,
+        'Invalid credentials',
+      );
+    }
 
     return this.buildAuthResponse(user.id);
   }
@@ -133,7 +156,12 @@ export class AuthService implements OnModuleInit {
 
   async register(input: RegistrationInput): Promise<AuthResponse> {
     const existing = await this.userRepo.findByEmail(input.email);
-    if (existing) throw new ConflictException('Email already registered');
+    if (existing) {
+      throw new AuthError(
+        AuthErrorCode.EMAIL_ALREADY_EXISTS,
+        'Email already registered',
+      );
+    }
 
     const hashed = await this.passwordHasher.hash(input.password);
     const user = await this.userRepo.create({
@@ -151,8 +179,12 @@ export class AuthService implements OnModuleInit {
 
   async handleGoogleCallback(requestUser: RequestUser): Promise<AuthResponse> {
     const user = await this.userRepo.findById(requestUser.userId);
-    if (!user?.id)
-      throw new UnauthorizedException('User not found after Google OAuth');
+    if (!user?.id) {
+      throw new AuthError(
+        AuthErrorCode.OAUTH_USER_NOT_FOUND,
+        'User not found after Google OAuth',
+      );
+    }
     return this.buildAuthResponse(user.id);
   }
 
@@ -160,7 +192,12 @@ export class AuthService implements OnModuleInit {
 
   async rotateRefreshToken(plainToken: string): Promise<AuthResponse> {
     this.assertRefreshEnabled();
-    if (!plainToken) throw new BadRequestException('Refresh token is required');
+    if (!plainToken) {
+      throw new AuthError(
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
+        'Refresh token is required',
+      );
+    }
 
     const tokenHash = this.tokenHasher.hash(plainToken);
 
@@ -169,18 +206,27 @@ export class AuthService implements OnModuleInit {
     const stored = await this.refreshTokenRepo!.consumeByTokenHash(tokenHash);
 
     if (!stored) {
-      throw new UnauthorizedException(
+      throw new AuthError(
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
         'Refresh token is invalid or has already been used',
       );
     }
 
     if (new Date() > stored.expiresAt) {
       // Token was consumed above; no further cleanup needed.
-      throw new UnauthorizedException('Refresh token has expired');
+      throw new AuthError(
+        AuthErrorCode.REFRESH_TOKEN_EXPIRED,
+        'Refresh token has expired',
+      );
     }
 
     const user = await this.userRepo.findById(stored.userId);
-    if (!user?.id) throw new UnauthorizedException('User no longer exists');
+    if (!user?.id) {
+      throw new AuthError(
+        AuthErrorCode.OAUTH_USER_NOT_FOUND,
+        'User no longer exists',
+      );
+    }
 
     return this.buildAuthResponse(user.id);
   }
@@ -200,10 +246,13 @@ export class AuthService implements OnModuleInit {
     input: PasswordChangeInput,
   ): Promise<{ message: string }> {
     const user = await this.userRepo.findById(input.userId);
-    if (!user) throw new NotFoundException('User not found');
+    if (!user) {
+      throw new AuthError(AuthErrorCode.USER_NOT_FOUND, 'User not found');
+    }
 
     if (!('password' in user) || !user.password) {
-      throw new BadRequestException(
+      throw new AuthError(
+        AuthErrorCode.OAUTH_ACCOUNT_NO_PASSWORD,
         'Password cannot be changed on OAuth-only accounts',
       );
     }
@@ -212,15 +261,20 @@ export class AuthService implements OnModuleInit {
       input.currentPassword,
       user.password as string,
     );
-    if (!currentValid)
-      throw new UnauthorizedException('Current password is incorrect');
+    if (!currentValid) {
+      throw new AuthError(
+        AuthErrorCode.INVALID_CREDENTIALS,
+        'Current password is incorrect',
+      );
+    }
 
     const isSame = await this.passwordHasher.verify(
       input.newPassword,
       user.password as string,
     );
     if (isSame) {
-      throw new BadRequestException(
+      throw new AuthError(
+        AuthErrorCode.PASSWORD_SAME_AS_OLD,
         'New password must differ from the current password',
       );
     }
@@ -235,7 +289,9 @@ export class AuthService implements OnModuleInit {
 
   async setPassword(input: PasswordSetInput): Promise<{ message: string }> {
     const user = await this.userRepo.findById(input.userId);
-    if (!user) throw new NotFoundException('User not found');
+    if (!user) {
+      throw new AuthError(AuthErrorCode.USER_NOT_FOUND, 'User not found');
+    }
 
     const hashed = await this.passwordHasher.hash(input.newPassword);
     await this.userRepo.update(input.userId, {
@@ -250,26 +306,23 @@ export class AuthService implements OnModuleInit {
   /**
    * Verify an access token and return its payload.
    *
-   * Use this if you want to write a custom guard without Passport, or if you
-   * are swapping `@nestjs/passport` for a different HTTP middleware layer.
+   * Use this to build framework-agnostic guards, or when replacing Passport
+   * with a different middleware layer. The token must have been issued with
+   * `type: 'access'` — refresh tokens are rejected.
    *
    * ```ts
-   * // custom-auth.guard.ts
-   * @Injectable()
-   * export class CustomAuthGuard implements CanActivate {
-   *   constructor(private readonly authService: AuthService) {}
-   *
-   *   async canActivate(ctx: ExecutionContext): Promise<boolean> {
-   *     const req = ctx.switchToHttp().getRequest();
-   *     const token = req.headers.authorization?.slice(7);
-   *     if (!token) throw new UnauthorizedException();
-   *     req.user = await this.authService.verifyAccessToken(token);
-   *     return true;
-   *   }
-   * }
+   * // Fastify hook (no NestJS):
+   * fastify.addHook('preHandler', async (request) => {
+   *   const token = request.headers.authorization?.slice(7);
+   *   if (!token) throw fastify.httpErrors.unauthorized();
+   *   request.user = await authService.verifyAccessToken(token);
+   * });
    * ```
    *
-   * @throws `UnauthorizedException` for invalid, expired, or malformed tokens.
+   * @throws `AuthError` with code `REFRESH_TOKEN_INVALID` for invalid,
+   *         expired, or malformed tokens (the same code is reused because
+   *         the failure mode is identical from the caller's perspective —
+   *         the token does not entitle access).
    */
   async verifyAccessToken(token: string): Promise<RequestUser> {
     try {
@@ -278,7 +331,10 @@ export class AuthService implements OnModuleInit {
       if (payload.type !== 'access') throw new Error('wrong token type');
       return { userId: payload.sub };
     } catch {
-      throw new UnauthorizedException('Invalid or expired access token');
+      throw new AuthError(
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
+        'Invalid or expired access token',
+      );
     }
   }
 
@@ -325,16 +381,11 @@ export class AuthService implements OnModuleInit {
   }
 
   private assertRefreshEnabled(): void {
-    if (!this.refreshTokenRepo) {
-      throw new BadRequestException(
+    if (!this.refreshTokenRepo || !this.jwtConfig.refreshToken) {
+      throw new AuthError(
+        AuthErrorCode.REFRESH_NOT_ENABLED,
         'Refresh tokens are not enabled. Provide a refreshTokenRepository ' +
-          'in AuthModule.forRootAsync().',
-      );
-    }
-    if (!this.jwtConfig.refreshToken) {
-      throw new BadRequestException(
-        'Refresh tokens are not enabled. Set jwt.refreshToken in the module ' +
-          'config to activate refresh-token issuance.',
+          'and a jwt.refreshToken config block in AuthModule.forRootAsync().',
       );
     }
   }

--- a/src/errors/auth-error.ts
+++ b/src/errors/auth-error.ts
@@ -1,0 +1,72 @@
+/**
+ * Typed error codes for every failure condition `AuthService` can produce.
+ *
+ * Consumers who use `AuthService` outside NestJS catch `AuthError` and map
+ * these codes to whatever their framework expects. The NestJS adapter layer
+ * (`AuthExceptionFilter`) maps them to HTTP responses automatically.
+ */
+export const AuthErrorCode = {
+  // ── Credentials ───────────────────────────────────────────────────────────
+  /** Email not found, or password does not match the stored hash. */
+  INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+  /** Registration attempted with an email that already exists. */
+  EMAIL_ALREADY_EXISTS: 'EMAIL_ALREADY_EXISTS',
+  /** Password change/set requested on an OAuth-only account. */
+  OAUTH_ACCOUNT_NO_PASSWORD: 'OAUTH_ACCOUNT_NO_PASSWORD',
+  /** New password is identical to the current password. */
+  PASSWORD_SAME_AS_OLD: 'PASSWORD_SAME_AS_OLD',
+  /** User record not found when a specific userId was required. */
+  USER_NOT_FOUND: 'USER_NOT_FOUND',
+
+  // ── OAuth ─────────────────────────────────────────────────────────────────
+  /** `handleGoogleCallback` called but the user record no longer exists. */
+  OAUTH_USER_NOT_FOUND: 'OAUTH_USER_NOT_FOUND',
+
+  // ── Refresh tokens ────────────────────────────────────────────────────────
+  /** Token hash not found, or already consumed by a concurrent request. */
+  REFRESH_TOKEN_INVALID: 'REFRESH_TOKEN_INVALID',
+  /** Token was found but its `expiresAt` timestamp has passed. */
+  REFRESH_TOKEN_EXPIRED: 'REFRESH_TOKEN_EXPIRED',
+  /**
+   * `rotateRefreshToken` was called but refresh tokens are not enabled
+   * (missing repository or missing `jwt.refreshToken` config block).
+   * This is a server misconfiguration, not a bad client request.
+   */
+  REFRESH_NOT_ENABLED: 'REFRESH_NOT_ENABLED',
+} as const;
+
+export type AuthErrorCode = (typeof AuthErrorCode)[keyof typeof AuthErrorCode];
+
+/**
+ * The single error class thrown by `AuthService`.
+ *
+ * Carries a typed `code` for programmatic handling and a human-readable
+ * `message` for logs. Framework adapters map `code` to HTTP status codes
+ * or gRPC status codes — the core never decides that.
+ *
+ * ```ts
+ * // Plain Node.js / non-NestJS usage:
+ * try {
+ *   await authService.loginWithCredentials(input);
+ * } catch (err) {
+ *   if (err instanceof AuthError) {
+ *     switch (err.code) {
+ *       case AuthErrorCode.INVALID_CREDENTIALS: return reply.status(401).send();
+ *       case AuthErrorCode.USER_NOT_FOUND:      return reply.status(404).send();
+ *     }
+ *   }
+ *   throw err; // unexpected — re-throw
+ * }
+ * ```
+ */
+export class AuthError extends Error {
+  constructor(
+    public readonly code: AuthErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AuthError';
+    // Maintains correct instanceof chain in compiled JS.
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/src/errors/auth-error.ts
+++ b/src/errors/auth-error.ts
@@ -15,11 +15,19 @@ export const AuthErrorCode = {
   OAUTH_ACCOUNT_NO_PASSWORD: 'OAUTH_ACCOUNT_NO_PASSWORD',
   /** New password is identical to the current password. */
   PASSWORD_SAME_AS_OLD: 'PASSWORD_SAME_AS_OLD',
-  /** User record not found when a specific userId was required. */
+  /**
+   * User record not found when a specific `userId` was required.
+   * Thrown by: `changePassword`, `setPassword`, and `rotateRefreshToken`
+   * (when the user referenced by the refresh token no longer exists).
+   */
   USER_NOT_FOUND: 'USER_NOT_FOUND',
 
   // ── OAuth ─────────────────────────────────────────────────────────────────
-  /** `handleGoogleCallback` called but the user record no longer exists. */
+  /**
+   * `handleGoogleCallback` was called but the user record provisioned by
+   * `GoogleStrategy.validate()` could not be found immediately after.
+   * Indicates a race between user creation and the callback lookup.
+   */
   OAUTH_USER_NOT_FOUND: 'OAUTH_USER_NOT_FOUND',
 
   // ── Refresh tokens ────────────────────────────────────────────────────────

--- a/src/examples/auth.controller.example.ts
+++ b/src/examples/auth.controller.example.ts
@@ -1,18 +1,33 @@
 /**
  * @file auth.controller.example.ts
  *
- * Reference-only controller showing how to wire every `AuthService` method
- * into a NestJS controller. Copy and adapt — do not import this file.
+ * Reference-only file showing how to wire `AuthService` in two contexts:
+ *
+ * 1. **NestJS controller** — the standard path when using `AuthModule`.
+ * 2. **Framework-agnostic handler** — plain Node.js usage without NestJS,
+ *    demonstrating that `AuthService` works in any runtime.
+ *
+ * Copy and adapt the section relevant to you. Do not import this file.
  *
  * This file is excluded from the production build (`tsconfig.build.json`)
  * and is never shipped in the `dist/` output.
- *
- * ### Assumptions
- * - `JwtAuthGuard` is registered globally via `APP_GUARD` (recommended).
- *   Routes that must be publicly accessible are decorated with `@Public()`.
- * - `RegisterDto` / `LoginDto` / `ChangePasswordDto` are your own validation
- *   DTOs (e.g. class-validator). They are not provided by this module.
  */
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PART 1 — NestJS controller (Express or Fastify via @nestjs/platform-*)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// Prerequisites in app.module.ts:
+//
+//   providers: [
+//     // Maps AuthError codes to HTTP responses automatically.
+//     // Works with both Express and Fastify — uses NestJS ArgumentsHost.
+//     { provide: APP_GUARD,  useClass: JwtAuthGuard },
+//     { provide: APP_FILTER, useClass: AuthExceptionFilter },
+//   ]
+//
+// Without AuthExceptionFilter, AuthError propagates as an unhandled exception.
+// You can also scope it per-controller with @UseFilters(AuthExceptionFilter).
 
 import {
   Controller,
@@ -52,7 +67,7 @@ interface ChangePasswordDto {
   newPassword: string;
 }
 
-// ── Controller ────────────────────────────────────────────────────────────
+// ── NestJS controller ─────────────────────────────────────────────────────
 
 @Controller('auth')
 export class AuthController {
@@ -60,10 +75,6 @@ export class AuthController {
 
   // ── Credentials ──────────────────────────────────────────────────────────
 
-  /**
-   * POST /auth/register
-   * Create a new user and return a token pair.
-   */
   @Public()
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
@@ -71,10 +82,6 @@ export class AuthController {
     return this.authService.register(dto);
   }
 
-  /**
-   * POST /auth/login
-   * Verify email + password and return a token pair.
-   */
   @Public()
   @Post('login')
   @HttpCode(HttpStatus.OK)
@@ -84,10 +91,6 @@ export class AuthController {
 
   // ── Google OAuth ──────────────────────────────────────────────────────────
 
-  /**
-   * GET /auth/google
-   * Redirects the browser to Google's OAuth consent screen.
-   */
   @Public()
   @Get('google')
   @UseGuards(GoogleOAuthGuard)
@@ -95,12 +98,6 @@ export class AuthController {
     // Passport handles the redirect — no body needed.
   }
 
-  /**
-   * GET /auth/google/callback
-   * Google redirects here after the user grants consent.
-   * Passport calls GoogleStrategy.validate(), which resolves req.user,
-   * then this handler issues a token pair.
-   */
   @Public()
   @Get('google/callback')
   @UseGuards(GoogleOAuthGuard)
@@ -110,11 +107,6 @@ export class AuthController {
 
   // ── Refresh tokens ────────────────────────────────────────────────────────
 
-  /**
-   * POST /auth/refresh
-   * Atomically consume the supplied refresh token and issue a fresh pair.
-   * The old token is invalidated immediately — replay is rejected.
-   */
   @Public()
   @Post('refresh')
   @HttpCode(HttpStatus.OK)
@@ -122,11 +114,6 @@ export class AuthController {
     return this.authService.rotateRefreshToken(dto.refreshToken);
   }
 
-  /**
-   * POST /auth/logout
-   * Revoke every refresh token for the authenticated user (all devices).
-   * Access tokens remain valid until their `exp` claim — keep TTLs short.
-   */
   @Post('logout')
   @HttpCode(HttpStatus.NO_CONTENT)
   logout(@CurrentUser() user: RequestUser) {
@@ -135,11 +122,6 @@ export class AuthController {
 
   // ── Protected ─────────────────────────────────────────────────────────────
 
-  /**
-   * GET /auth/me
-   * Return the authenticated user's identity.
-   * Protected by the global JwtAuthGuard — no @UseGuards needed.
-   */
   @Get('me')
   me(@CurrentUser() user: RequestUser) {
     return user;
@@ -147,11 +129,6 @@ export class AuthController {
 
   // ── Password management ───────────────────────────────────────────────────
 
-  /**
-   * POST /auth/password/change
-   * Change the authenticated user's password.
-   * Requires the current password for verification.
-   */
   @Post('password/change')
   @HttpCode(HttpStatus.OK)
   changePassword(
@@ -165,3 +142,124 @@ export class AuthController {
     });
   }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// PART 2 — Framework-agnostic usage (no NestJS, no Passport)
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// AuthService is a plain class. Construct it directly with any framework.
+// AuthError carries typed codes — map them to whatever your framework expects.
+//
+// Example below uses Fastify directly, but the same pattern works for:
+//   plain Express, Hono, Elysia, Koa, queue workers, Lambda, CLI tools, etc.
+
+/*
+import Fastify from 'fastify';
+import { AuthService } from '@odysseon/auth';
+import { AuthError, AuthErrorCode } from '@odysseon/auth';
+import { JoseJwtSigner } from '@odysseon/auth';
+import { Argon2PasswordHasher } from '@odysseon/auth';
+import { CryptoTokenHasher } from '@odysseon/auth';
+import { ConsoleLogger } from '@odysseon/auth';
+
+// ── Wire AuthService without NestJS ───────────────────────────────────────
+
+const jwtConfig = {
+  type: 'symmetric' as const,
+  secret: process.env.JWT_SECRET!,
+  accessToken: { expiresIn: '15m', algorithm: 'HS256' },
+  refreshToken: { expiresIn: '7d' },
+};
+
+const authService = new AuthService(
+  jwtConfig,
+  new JoseJwtSigner(),
+  new Argon2PasswordHasher(),
+  new CryptoTokenHasher(),
+  new ConsoleLogger(),
+  new MyUserRepository(),        // your IUserRepository implementation
+  new MyRefreshTokenRepository(), // your IRefreshTokenRepository implementation
+);
+
+// Call init() once at startup — validates config and imports JWT keys.
+await authService.init();
+
+// ── Map AuthError codes to HTTP responses ─────────────────────────────────
+
+const AUTH_ERROR_STATUS: Record<string, number> = {
+  [AuthErrorCode.INVALID_CREDENTIALS]:       401,
+  [AuthErrorCode.EMAIL_ALREADY_EXISTS]:      409,
+  [AuthErrorCode.OAUTH_ACCOUNT_NO_PASSWORD]: 400,
+  [AuthErrorCode.PASSWORD_SAME_AS_OLD]:      400,
+  [AuthErrorCode.USER_NOT_FOUND]:            404,
+  [AuthErrorCode.OAUTH_USER_NOT_FOUND]:      401,
+  [AuthErrorCode.REFRESH_TOKEN_INVALID]:     401,
+  [AuthErrorCode.REFRESH_TOKEN_EXPIRED]:     401,
+  [AuthErrorCode.REFRESH_NOT_ENABLED]:       501,
+};
+
+function handleAuthError(err: unknown, reply: FastifyReply): boolean {
+  if (err instanceof AuthError) {
+    const status = AUTH_ERROR_STATUS[err.code] ?? 500;
+    reply.status(status).send({ error: err.code, message: err.message });
+    return true;
+  }
+  return false;
+}
+
+// ── Fastify routes ────────────────────────────────────────────────────────
+
+const fastify = Fastify();
+
+fastify.post('/auth/register', async (request, reply) => {
+  try {
+    const body = request.body as { email: string; password: string };
+    const result = await authService.register(body);
+    return reply.status(201).send(result);
+  } catch (err) {
+    if (!handleAuthError(err, reply)) throw err;
+  }
+});
+
+fastify.post('/auth/login', async (request, reply) => {
+  try {
+    const body = request.body as { email: string; password: string };
+    const result = await authService.loginWithCredentials(body);
+    return reply.send(result);
+  } catch (err) {
+    if (!handleAuthError(err, reply)) throw err;
+  }
+});
+
+fastify.post('/auth/refresh', async (request, reply) => {
+  try {
+    const body = request.body as { refreshToken: string };
+    const result = await authService.rotateRefreshToken(body.refreshToken);
+    return reply.send(result);
+  } catch (err) {
+    if (!handleAuthError(err, reply)) throw err;
+  }
+});
+
+// Protect routes manually — verify the access token in a preHandler hook.
+fastify.addHook('preHandler', async (request, reply) => {
+  // Skip public routes.
+  const publicPaths = ['/auth/register', '/auth/login', '/auth/refresh'];
+  if (publicPaths.includes(request.url)) return;
+
+  const token = request.headers.authorization?.slice(7); // strip "Bearer "
+  if (!token) return reply.status(401).send({ error: 'Missing token' });
+
+  try {
+    (request as any).user = await authService.verifyAccessToken(token);
+  } catch {
+    return reply.status(401).send({ error: 'Invalid or expired token' });
+  }
+});
+
+fastify.get('/auth/me', async (request) => {
+  return (request as any).user;
+});
+
+await fastify.listen({ port: 3000 });
+*/

--- a/src/filters/auth-exception.filter.ts
+++ b/src/filters/auth-exception.filter.ts
@@ -1,0 +1,61 @@
+import {
+  Catch,
+  ExceptionFilter,
+  ArgumentsHost,
+  HttpStatus,
+} from '@nestjs/common';
+import { AuthError, AuthErrorCode } from '../errors/auth-error';
+
+/**
+ * NestJS exception filter that maps `AuthError` domain errors to HTTP
+ * responses. Register it globally or per-controller in the consuming app:
+ *
+ * ```ts
+ * // Global — app.module.ts
+ * providers: [{ provide: APP_FILTER, useClass: AuthExceptionFilter }]
+ *
+ * // Per-controller
+ * @UseFilters(AuthExceptionFilter)
+ * @Controller('auth')
+ * export class AuthController { ... }
+ * ```
+ *
+ * Works with both Express and Fastify — it accesses the response through
+ * NestJS's `ArgumentsHost` abstraction, not through a framework-specific API.
+ */
+@Catch(AuthError)
+export class AuthExceptionFilter implements ExceptionFilter {
+  private static readonly STATUS_MAP: Record<AuthErrorCode, HttpStatus> = {
+    [AuthErrorCode.INVALID_CREDENTIALS]: HttpStatus.UNAUTHORIZED,
+    [AuthErrorCode.EMAIL_ALREADY_EXISTS]: HttpStatus.CONFLICT,
+    [AuthErrorCode.OAUTH_ACCOUNT_NO_PASSWORD]: HttpStatus.BAD_REQUEST,
+    [AuthErrorCode.PASSWORD_SAME_AS_OLD]: HttpStatus.BAD_REQUEST,
+    [AuthErrorCode.USER_NOT_FOUND]: HttpStatus.NOT_FOUND,
+    [AuthErrorCode.OAUTH_USER_NOT_FOUND]: HttpStatus.UNAUTHORIZED,
+    [AuthErrorCode.REFRESH_TOKEN_INVALID]: HttpStatus.UNAUTHORIZED,
+    [AuthErrorCode.REFRESH_TOKEN_EXPIRED]: HttpStatus.UNAUTHORIZED,
+    [AuthErrorCode.REFRESH_NOT_ENABLED]: HttpStatus.NOT_IMPLEMENTED,
+  };
+
+  catch(error: AuthError, host: ArgumentsHost): void {
+    const status =
+      AuthExceptionFilter.STATUS_MAP[error.code] ??
+      HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const body = {
+      statusCode: status,
+      error: error.code,
+      message: error.message,
+    };
+
+    const http = host.switchToHttp();
+
+    // NestJS's HttpArgumentsHost works identically for Express and Fastify —
+    // getResponse() returns the platform's response object and the `.status()`
+    // / `.send()` / `.json()` methods are normalised by the NestJS adapter.
+    const response = http.getResponse<{
+      status(code: number): { json(body: unknown): void };
+    }>();
+    response.status(status).json(body);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,17 @@
 // ── Module & Service ──────────────────────────────────────────────────────
 export { AuthModule } from './core/auth.module';
-export type { AuthModuleAdapterOverrides } from './core/auth.module';
+export type {
+  AuthModuleAsyncOptions,
+  AuthModuleAdapterOverrides,
+} from './core/auth.module';
 export { AuthService } from './core/auth.service';
+
+// ── Error types ───────────────────────────────────────────────────────────
+export { AuthError, AuthErrorCode } from './errors/auth-error';
+export type { AuthErrorCode as AuthErrorCodeType } from './errors/auth-error';
+
+// ── NestJS HTTP adapter ───────────────────────────────────────────────────
+export { AuthExceptionFilter } from './filters/auth-exception.filter';
 
 // ── Guards ────────────────────────────────────────────────────────────────
 export { JwtAuthGuard } from './guards/jwt-auth.guard';
@@ -12,21 +22,16 @@ export { CurrentUser } from './decorators/current-user.decorator';
 export { Public, IS_PUBLIC_KEY } from './decorators/public.decorator';
 
 // ── Default adapters (swappable — see interfaces/ports/ for the contracts) ─
-// Import these to extend or reference default implementations.
-// Pass your own class to AuthModule.forRootAsync() to replace any of them.
 export { JoseJwtSigner } from './adapters/jose-jwt-signer.adapter';
 export { Argon2PasswordHasher } from './adapters/argon2-password-hasher.adapter';
 export { CryptoTokenHasher } from './adapters/crypto-token-hasher.adapter';
 export { BearerTokenExtractor } from './adapters/bearer-token-extractor.adapter';
 export { CookieTokenExtractor } from './adapters/cookie-token-extractor.adapter';
 export { QueryParamTokenExtractor } from './adapters/query-param-token-extractor.adapter';
+export { ConsoleLogger } from './adapters/console-logger.adapter';
 
 // ── Full interface surface ─────────────────────────────────────────────────
-// IUserRepository, IGoogleUserRepository, IRefreshTokenRepository
-//   → implement in your infrastructure layer (ORM adapters etc.)
-// IJwtSigner, IPasswordHasher, ITokenHasher, ITokenExtractor
-//   → implement to swap out default external library adapters
 export * from './interfaces';
 
-// ── DI tokens (for testing overrides and advanced wiring) ─────────────────
+// ── DI tokens ─────────────────────────────────────────────────────────────
 export { AUTH_CAPABILITIES, PORTS, AUTH_CONFIG } from './constants';

--- a/src/interfaces/README.md
+++ b/src/interfaces/README.md
@@ -15,6 +15,7 @@ The core layer depends on these; adapters implement them.
 | `IPasswordHasher` | `Argon2PasswordHasher` (argon2) | `passwordHasher:` in `forRootAsync()` |
 | `ITokenHasher` | `CryptoTokenHasher` (node:crypto) | `tokenHasher:` in `forRootAsync()` |
 | `ITokenExtractor` | `BearerTokenExtractor` (Authorization header) | `tokenExtractor:` in `forRootAsync()` |
+| `ILogger` | `ConsoleLogger` (console.log / console.error) | `logger:` in `forRootAsync()` |
 
 ### `configuration/`
 Config shapes passed to `AuthModule.forRootAsync()`.
@@ -23,7 +24,11 @@ Config shapes passed to `AuthModule.forRootAsync()`.
 |---|---|
 | `jwt-config.interface.ts` | `JwtConfig` — symmetric vs asymmetric, access + refresh TTLs |
 | `google-oauth-config.interface.ts` | `GoogleOAuthConfig` — clientID, secret, callbackURL |
-| `auth-module-config.interface.ts` | `AuthModuleConfig` + `AuthModuleAsyncOptions` |
+| `auth-module-config.interface.ts` | `AuthModuleConfig` — the pure domain config object |
+
+Note: `AuthModuleAsyncOptions` (the NestJS wiring type) lives in
+`core/auth.module.ts` alongside `forRootAsync()`, not here, because it
+imports NestJS types and belongs in the adapter layer.
 
 ### `user-model/`
 Contracts for user entities and their repository.
@@ -32,7 +37,7 @@ Contracts for user entities and their repository.
 |---|---|
 | `user.interface.ts` | `AuthUser`, `BaseUser`, `CredentialsUser`, `GoogleUser` |
 | `request-user.interface.ts` | `RequestUser` — what lands on `req.user` after JWT validation |
-| `authenticated-request.interface.ts` | Express `Request` extended with `user: RequestUser` |
+| `authenticated-request.interface.ts` | Minimal `{ user: RequestUser }` — framework-agnostic, no Express import |
 | `user-repository.interface.ts` | `IUserRepository` + `IGoogleUserRepository` — implement these |
 
 ### `refresh-token/`

--- a/src/interfaces/configuration/auth-module-config.interface.ts
+++ b/src/interfaces/configuration/auth-module-config.interface.ts
@@ -1,11 +1,12 @@
-import type { ModuleMetadata, Type, FactoryProvider } from '@nestjs/common';
 import type { JwtConfig } from './jwt-config.interface';
 import type { GoogleOAuthConfig } from './google-oauth-config.interface';
-import type { AuthUser, IUserRepository } from '../user-model';
-import type { IRefreshToken, IRefreshTokenRepository } from '../refresh-token';
 
 /**
  * The fully-resolved configuration object returned by `useFactory`.
+ *
+ * This is a pure TypeScript type — no framework imports.
+ * `AuthModuleAsyncOptions` (the NestJS wiring type) lives in `auth.module.ts`
+ * alongside `forRootAsync()`, where framework coupling is intentional.
  */
 export interface AuthModuleConfig {
   /** JWT signing/verification configuration. Required. */
@@ -15,36 +16,4 @@ export interface AuthModuleConfig {
    * Required when `'google'` is listed in `enabledCapabilities`.
    */
   google?: GoogleOAuthConfig;
-}
-
-/**
- * Async registration options — mirrors the standard NestJS
- * `*AsyncOptions` pattern so consumers can inject `ConfigService` etc.
- */
-export interface AuthModuleAsyncOptions<
-  User extends Partial<AuthUser> = Partial<AuthUser>,
-  RT extends IRefreshToken = IRefreshToken,
->
-  extends
-    Pick<ModuleMetadata, 'imports'>,
-    Pick<FactoryProvider<AuthModuleConfig>, 'useFactory' | 'inject'> {
-  /**
-   * Class that implements `IUserRepository` (or `IGoogleUserRepository`
-   * when google is enabled).  Registered as a provider so it can itself
-   * receive injected dependencies.
-   */
-  userRepository: Type<IUserRepository<User>>;
-
-  /**
-   * Class that implements `IRefreshTokenRepository`.
-   * When omitted, refresh-token rotation is disabled and
-   * `AuthService.rotateRefreshToken()` will throw.
-   */
-  refreshTokenRepository?: Type<IRefreshTokenRepository<RT>>;
-
-  /**
-   * Explicitly opt in to each authentication capability you need.
-   * Only the listed capabilities will have their providers registered.
-   */
-  enabledCapabilities: Array<'credentials' | 'google'>;
 }

--- a/src/interfaces/configuration/jwt-config.interface.spec.ts
+++ b/src/interfaces/configuration/jwt-config.interface.spec.ts
@@ -104,4 +104,51 @@ describe('validateJwtConfig', () => {
       );
     });
   });
+
+  describe('refreshToken.tokenLength validation', () => {
+    it('does not throw when tokenLength is absent', () => {
+      expect(() =>
+        validateJwtConfig({
+          ...VALID_SYMMETRIC,
+          refreshToken: { expiresIn: '7d' },
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when tokenLength is exactly 16', () => {
+      expect(() =>
+        validateJwtConfig({
+          ...VALID_SYMMETRIC,
+          refreshToken: { expiresIn: '7d', tokenLength: 16 },
+        }),
+      ).not.toThrow();
+    });
+
+    it('does not throw when tokenLength is above 16', () => {
+      expect(() =>
+        validateJwtConfig({
+          ...VALID_SYMMETRIC,
+          refreshToken: { expiresIn: '7d', tokenLength: 64 },
+        }),
+      ).not.toThrow();
+    });
+
+    it('throws when tokenLength is below 16', () => {
+      expect(() =>
+        validateJwtConfig({
+          ...VALID_SYMMETRIC,
+          refreshToken: { expiresIn: '7d', tokenLength: 8 },
+        }),
+      ).toThrow('at least 16 bytes');
+    });
+
+    it('throws when tokenLength is 1', () => {
+      expect(() =>
+        validateJwtConfig({
+          ...VALID_SYMMETRIC,
+          refreshToken: { expiresIn: '7d', tokenLength: 1 },
+        }),
+      ).toThrow('at least 16 bytes');
+    });
+  });
 });

--- a/src/interfaces/configuration/jwt-config.interface.ts
+++ b/src/interfaces/configuration/jwt-config.interface.ts
@@ -70,6 +70,10 @@ export function isAsymmetric(cfg: JwtConfig): cfg is AsymmetricJwtConfig {
 
 /**
  * Validates `JwtConfig` at module initialisation.
+ *
+ * Throws a descriptive `Error` for every detectable misconfiguration so that
+ * bad config crashes the application at startup rather than silently producing
+ * insecure tokens at request time.
  */
 export function validateJwtConfig(cfg: JwtConfig): void {
   if (!cfg.accessToken?.expiresIn) {
@@ -92,5 +96,15 @@ export function validateJwtConfig(cfg: JwtConfig): void {
           'required for asymmetric config.',
       );
     }
+  }
+
+  if (
+    cfg.refreshToken?.tokenLength !== undefined &&
+    cfg.refreshToken.tokenLength < 16
+  ) {
+    throw new Error(
+      '[@odysseon/auth] jwt.refreshToken.tokenLength must be at least 16 bytes ' +
+        '(128 bits). Values below this threshold provide insufficient entropy.',
+    );
   }
 }

--- a/src/interfaces/ports/README.md
+++ b/src/interfaces/ports/README.md
@@ -57,6 +57,20 @@ never throw.
 Default adapter: `BearerTokenExtractor` (`Authorization: Bearer <token>`)
 Swap to: `CookieTokenExtractor`, `QueryParamTokenExtractor`, or a custom implementation
 
+### `ILogger`
+Abstracts informational logging inside `AuthService`.
+
+| Method | Signature |
+|---|---|
+| `log` | `(message: string) → void` |
+| `error` | `(message: string, context?: unknown) → void` |
+
+Default adapter: `ConsoleLogger` (zero deps — `console.log` / `console.error`)
+Swap to: NestJS `Logger`, Pino, Winston, or any sink
+
+`ConsoleLogger` has **no framework imports** — it is a plain class that works
+in any Node.js runtime without NestJS installed.
+
 ## Rule
 
 **Nothing in `ports/` may import from adapters or from any external library.**
@@ -72,6 +86,7 @@ AuthModule.forRootAsync({
   passwordHasher: MyPasswordHasher,  // replaces Argon2PasswordHasher
   tokenHasher:    MyTokenHasher,     // replaces CryptoTokenHasher
   tokenExtractor: MyTokenExtractor,  // replaces BearerTokenExtractor
+  logger:         MyLogger,          // replaces ConsoleLogger
 })
 ```
 

--- a/src/interfaces/ports/index.ts
+++ b/src/interfaces/ports/index.ts
@@ -2,3 +2,4 @@ export * from './password-hasher.port';
 export * from './token-hasher.port';
 export * from './jwt-signer.port';
 export * from './token-extractor.port';
+export * from './logger.port';

--- a/src/interfaces/ports/jwt-signer.port.ts
+++ b/src/interfaces/ports/jwt-signer.port.ts
@@ -63,7 +63,8 @@ export interface IJwtSigner {
    * regardless of which adapter is in use.
    *
    * @throws Any error on invalid signature, expiry, or claim mismatch.
-   *         `AuthService` will wrap thrown errors in `UnauthorizedException`.
+   *         `AuthService` will wrap thrown errors in `AuthError` with code
+   *         `REFRESH_TOKEN_INVALID`.
    */
   verify(token: string): Promise<JwtPayload>;
 }

--- a/src/interfaces/ports/logger.port.ts
+++ b/src/interfaces/ports/logger.port.ts
@@ -1,0 +1,27 @@
+/**
+ * Port: structured logging.
+ *
+ * `AuthService` depends only on this interface — it never imports
+ * `@nestjs/common`'s `Logger` or any other logging library directly.
+ *
+ * The default adapter (`ConsoleLogger`) writes to stdout via `console.log`.
+ * Swap it to get NestJS structured logging, Pino, Winston, or any sink:
+ *
+ * ```ts
+ * // nestjs-logger.adapter.ts
+ * import { Logger } from '@nestjs/common';
+ *
+ * @Injectable()
+ * export class NestJsLogger implements ILogger {
+ *   private readonly logger = new Logger('AuthService');
+ *   log(message: string)                    { this.logger.log(message); }
+ *   error(message: string, ctx?: unknown)   { this.logger.error(message, ctx); }
+ * }
+ *
+ * // AuthModule.forRootAsync({ logger: NestJsLogger, ... })
+ * ```
+ */
+export interface ILogger {
+  log(message: string): void;
+  error(message: string, context?: unknown): void;
+}

--- a/src/interfaces/user-model/authenticated-request.interface.ts
+++ b/src/interfaces/user-model/authenticated-request.interface.ts
@@ -1,7 +1,26 @@
-import type { Request } from 'express';
 import type { RequestUser } from './request-user.interface';
 
-/** Express Request extended with a validated user identity. */
-export interface AuthenticatedRequest extends Request {
+/**
+ * Minimal request shape that carries a validated user identity.
+ *
+ * Intentionally framework-agnostic — this interface requires only the
+ * `user` property that the auth module reads. It is structurally compatible
+ * with Express's `Request`, Fastify's `FastifyRequest`, and any other
+ * framework's request object.
+ *
+ * ```ts
+ * // Express
+ * @Get('me')
+ * me(@Req() req: AuthenticatedRequest) { return req.user; }
+ *
+ * // Fastify
+ * @Get('me')
+ * me(@Req() req: AuthenticatedRequest) { return req.user; }
+ *
+ * // Plain Node.js (no framework)
+ * const user: RequestUser = (req as AuthenticatedRequest).user;
+ * ```
+ */
+export interface AuthenticatedRequest {
   user: RequestUser;
 }

--- a/src/strategies/README.md
+++ b/src/strategies/README.md
@@ -45,6 +45,19 @@ into `AuthService` would require a more complex interface. The strategy
 acts as the "Google adapter" at the Passport boundary; `AuthService` stays
 focused on token issuance.
 
+### Error handling in `validate()`
+
+Two categories of failure are distinguished:
+
+- **Expected auth failures** (no email returned, user cannot be resolved):
+  `done(new UnauthorizedException(...))`. Passport recognises `HttpException`
+  instances and routes them through the *fail* path, producing a 401. The
+  client receives the correct status without the error surfacing as a crash.
+
+- **Unexpected exceptions** (repository errors, network failures):
+  `done(err)` in the `catch` block. Passport routes these through the *error*
+  path, producing a 500 and preserving the original stack trace for debugging.
+
 ## Adding a new strategy
 
 1. Create `src/strategies/my-provider.strategy.ts`.

--- a/src/strategies/google.strategy.spec.ts
+++ b/src/strategies/google.strategy.spec.ts
@@ -1,4 +1,3 @@
-import { UnauthorizedException } from '@nestjs/common';
 import { GoogleStrategy } from './google.strategy';
 import type { IGoogleUserRepository } from '../interfaces';
 import type { AuthUser } from '../interfaces/user-model/user.interface';
@@ -26,13 +25,7 @@ describe('GoogleStrategy', () => {
       emails: [{ value: 'user@example.com', verified: true }],
       photos: [],
       _raw: '',
-      _json: {
-        iss: '',
-        aud: '',
-        sub: '',
-        iat: 0,
-        exp: 0,
-      },
+      _json: { iss: '', aud: '', sub: '', iat: 0, exp: 0 },
       ...overrides,
     };
   }
@@ -129,16 +122,16 @@ describe('GoogleStrategy', () => {
       expect(done).toHaveBeenCalledWith(null, { userId: 'user-3' });
     });
 
-    it('calls done with UnauthorizedException when no email in profile', async () => {
+    it('calls done with an Error when no email in profile', async () => {
       const { strategy } = buildStrategy();
       const done = jest.fn() as jest.MockedFunction<VerifyCallback>;
 
       await strategy.validate('at', 'rt', buildProfile({ emails: [] }), done);
 
-      expect(done).toHaveBeenCalledWith(expect.any(UnauthorizedException));
+      expect(done).toHaveBeenCalledWith(expect.any(Error));
     });
 
-    it('calls done with UnauthorizedException when user id cannot be resolved', async () => {
+    it('calls done with an Error when user id cannot be resolved', async () => {
       const { strategy } = buildStrategy({
         findByGoogleId: jest.fn().mockResolvedValue(null),
         findByEmail: jest.fn().mockResolvedValue(null),
@@ -148,7 +141,7 @@ describe('GoogleStrategy', () => {
 
       await strategy.validate('at', 'rt', buildProfile(), done);
 
-      expect(done).toHaveBeenCalledWith(expect.any(UnauthorizedException));
+      expect(done).toHaveBeenCalledWith(expect.any(Error));
     });
 
     it('calls done with the error when an unexpected exception is thrown', async () => {

--- a/src/strategies/google.strategy.spec.ts
+++ b/src/strategies/google.strategy.spec.ts
@@ -1,3 +1,4 @@
+import { UnauthorizedException } from '@nestjs/common';
 import { GoogleStrategy } from './google.strategy';
 import type { IGoogleUserRepository } from '../interfaces';
 import type { AuthUser } from '../interfaces/user-model/user.interface';
@@ -122,16 +123,16 @@ describe('GoogleStrategy', () => {
       expect(done).toHaveBeenCalledWith(null, { userId: 'user-3' });
     });
 
-    it('calls done with an Error when no email in profile', async () => {
+    it('calls done with UnauthorizedException when no email in profile', async () => {
       const { strategy } = buildStrategy();
       const done = jest.fn() as jest.MockedFunction<VerifyCallback>;
 
       await strategy.validate('at', 'rt', buildProfile({ emails: [] }), done);
 
-      expect(done).toHaveBeenCalledWith(expect.any(Error));
+      expect(done).toHaveBeenCalledWith(expect.any(UnauthorizedException));
     });
 
-    it('calls done with an Error when user id cannot be resolved', async () => {
+    it('calls done with UnauthorizedException when user id cannot be resolved', async () => {
       const { strategy } = buildStrategy({
         findByGoogleId: jest.fn().mockResolvedValue(null),
         findByEmail: jest.fn().mockResolvedValue(null),
@@ -141,7 +142,7 @@ describe('GoogleStrategy', () => {
 
       await strategy.validate('at', 'rt', buildProfile(), done);
 
-      expect(done).toHaveBeenCalledWith(expect.any(Error));
+      expect(done).toHaveBeenCalledWith(expect.any(UnauthorizedException));
     });
 
     it('calls done with the error when an unexpected exception is thrown', async () => {

--- a/src/strategies/google.strategy.ts
+++ b/src/strategies/google.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy, Profile, VerifyCallback } from 'passport-google-oauth20';
 import { AUTH_CAPABILITIES, PORTS } from '../constants';
@@ -26,6 +26,10 @@ import type {
  *
  * Note: email-verification semantics are out of scope for this module and
  * are left entirely to the consuming application.
+ *
+ * ### Error handling
+ * `validate()` calls `done(error)` on failure rather than throwing
+ * framework-specific exceptions. Passport's error path handles the response.
  */
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -59,7 +63,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       const email = profile.emails?.[0]?.value;
       if (!email) {
         return done(
-          new UnauthorizedException(
+          new Error(
             'Google did not return an email address. Ensure your Google ' +
               'account has a verified email and the email scope is granted.',
           ),
@@ -87,11 +91,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       }
 
       if (!user?.id) {
-        return done(
-          new UnauthorizedException(
-            'Failed to resolve user from Google profile',
-          ),
-        );
+        return done(new Error('Failed to resolve user from Google profile'));
       }
 
       const requestUser: RequestUser = { userId: user.id };

--- a/src/strategies/google.strategy.ts
+++ b/src/strategies/google.strategy.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from '@nestjs/common';
+import { Injectable, Inject, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { Strategy, Profile, VerifyCallback } from 'passport-google-oauth20';
 import { AUTH_CAPABILITIES, PORTS } from '../constants';
@@ -28,8 +28,13 @@ import type {
  * are left entirely to the consuming application.
  *
  * ### Error handling
- * `validate()` calls `done(error)` on failure rather than throwing
- * framework-specific exceptions. Passport's error path handles the response.
+ * Expected authentication failures (missing email, unresolvable user) call
+ * `done(new UnauthorizedException(...))`. Passport routes `HttpException`
+ * instances through the *fail* path (401), not the *error* path (500), so
+ * the client receives the correct status code.
+ * Truly unexpected exceptions (repository errors, network failures) fall
+ * through to the `catch` block and call `done(err)`, which Passport routes
+ * through the error path — resulting in a 500 and surfacing the original error.
  */
 @Injectable()
 export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
@@ -63,7 +68,7 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       const email = profile.emails?.[0]?.value;
       if (!email) {
         return done(
-          new Error(
+          new UnauthorizedException(
             'Google did not return an email address. Ensure your Google ' +
               'account has a verified email and the email scope is granted.',
           ),
@@ -91,7 +96,11 @@ export class GoogleStrategy extends PassportStrategy(Strategy, 'google') {
       }
 
       if (!user?.id) {
-        return done(new Error('Failed to resolve user from Google profile'));
+        return done(
+          new UnauthorizedException(
+            'Failed to resolve user from Google profile',
+          ),
+        );
       }
 
       const requestUser: RequestUser = { userId: user.id };

--- a/test/auth-module.e2e-spec.ts
+++ b/test/auth-module.e2e-spec.ts
@@ -5,12 +5,13 @@
  * and verifies the full authentication lifecycle:
  *   register → login → refresh → logout
  *
- * No real database. No real argon2 (replaced with a fast bcrypt-free stub).
+ * No real database. No real argon2 (replaced with a fast plaintext stub).
  * No real HTTP server — requests go through the NestJS test client.
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication, Injectable } from '@nestjs/common';
 import { AuthModule } from '../src/core/auth.module';
+import { AuthError, AuthErrorCode } from '../src/errors/auth-error';
 import type { IUserRepository } from '../src/interfaces/user-model/user-repository.interface';
 import type { IRefreshTokenRepository } from '../src/interfaces/refresh-token/refresh-token.interface';
 import type { IRefreshToken } from '../src/interfaces/refresh-token/refresh-token.interface';
@@ -20,7 +21,7 @@ import { AuthService } from '../src/core/auth.service';
 
 // ── In-memory stubs ─────────────────────────────────────────────────────────
 
-type TestUser = Required<AuthUser> & { id: string };
+type TestUser = Required<Omit<AuthUser, 'isEmailVerified'>> & { id: string };
 
 @Injectable()
 class InMemoryUserRepository implements IUserRepository<TestUser> {
@@ -66,20 +67,11 @@ class InMemoryRefreshTokenRepository implements IRefreshTokenRepository {
     this.store.set(id, record);
     return Promise.resolve(record);
   }
-  findByTokenHash(hash: string) {
-    return Promise.resolve(
-      [...this.store.values()].find((t) => t.token === hash) ?? null,
-    );
-  }
   consumeByTokenHash(hash: string) {
     const record = [...this.store.values()].find((t) => t.token === hash);
     if (!record) return Promise.resolve(null);
     this.store.delete(record.id);
     return Promise.resolve(record);
-  }
-  deleteById(id: string) {
-    this.store.delete(id);
-    return Promise.resolve();
   }
   deleteAllForUser(userId: string) {
     for (const [id, token] of this.store) {
@@ -98,6 +90,13 @@ class PlaintextPasswordHasher implements IPasswordHasher {
   async verify(password: string, hash: string) {
     return hash === `plain:${password}`;
   }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function expectAuthError(promise: Promise<unknown>, code: AuthErrorCode) {
+  await expect(promise).rejects.toBeInstanceOf(AuthError);
+  await expect(promise).rejects.toHaveProperty('code', code);
 }
 
 // ── Test suite ───────────────────────────────────────────────────────────────
@@ -148,18 +147,19 @@ describe('AuthModule (e2e)', () => {
       expect(typeof result.refreshToken).toBe('string');
     });
 
-    it('throws ConflictException for duplicate email', async () => {
+    it('throws AuthError EMAIL_ALREADY_EXISTS for duplicate email', async () => {
       await authService.register({
         email: 'duplicate@example.com',
         password: 'password123',
       });
 
-      await expect(
+      await expectAuthError(
         authService.register({
           email: 'duplicate@example.com',
           password: 'password456',
         }),
-      ).rejects.toThrow('Email already registered');
+        AuthErrorCode.EMAIL_ALREADY_EXISTS,
+      );
     });
   });
 
@@ -181,22 +181,24 @@ describe('AuthModule (e2e)', () => {
       expect(typeof result.accessToken).toBe('string');
     });
 
-    it('throws UnauthorizedException on wrong password', async () => {
-      await expect(
+    it('throws AuthError INVALID_CREDENTIALS on wrong password', async () => {
+      await expectAuthError(
         authService.loginWithCredentials({
           email: 'login@example.com',
           password: 'wrong-password',
         }),
-      ).rejects.toThrow('Invalid credentials');
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
 
-    it('throws UnauthorizedException for unknown email', async () => {
-      await expect(
+    it('throws AuthError INVALID_CREDENTIALS for unknown email', async () => {
+      await expectAuthError(
         authService.loginWithCredentials({
           email: 'nobody@example.com',
           password: 'password',
         }),
-      ).rejects.toThrow('Invalid credentials');
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
   });
 
@@ -206,15 +208,15 @@ describe('AuthModule (e2e)', () => {
         email: 'rotate@example.com',
         password: 'password',
       });
-
       const second = await authService.rotateRefreshToken(first.refreshToken!);
 
       expect(second.accessToken).toBeDefined();
       expect(second.refreshToken).toBeDefined();
-      // Old token must no longer be valid.
-      await expect(
+
+      await expectAuthError(
         authService.rotateRefreshToken(first.refreshToken!),
-      ).rejects.toThrow('invalid or has already been used');
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
+      );
     });
   });
 
@@ -227,9 +229,10 @@ describe('AuthModule (e2e)', () => {
 
       await authService.logout(user.userId);
 
-      await expect(
+      await expectAuthError(
         authService.rotateRefreshToken(refreshToken!),
-      ).rejects.toThrow('invalid or has already been used');
+        AuthErrorCode.REFRESH_TOKEN_INVALID,
+      );
     });
   });
 
@@ -253,19 +256,20 @@ describe('AuthModule (e2e)', () => {
       expect(result.user.userId).toBe(user.userId);
     });
 
-    it('rejects if the current password is wrong', async () => {
+    it('throws AuthError INVALID_CREDENTIALS when current password is wrong', async () => {
       const { user } = await authService.register({
         email: 'changepw-fail@example.com',
         password: 'password',
       });
 
-      await expect(
+      await expectAuthError(
         authService.changePassword({
           userId: user.userId,
           currentPassword: 'wrong',
           newPassword: 'new-password',
         }),
-      ).rejects.toThrow('Current password is incorrect');
+        AuthErrorCode.INVALID_CREDENTIALS,
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
<!-- What does this PR do? One paragraph. -->

## Type of change
- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `perf` — performance improvement
- [ ] `refactor` — code change, no behaviour change
- [ ] `docs` — documentation only
- [ ] `chore` — build, deps, tooling
- [ ] `test` — test changes only
- [ ] `ci` — CI/CD changes

## Breaking changes
- [ ] This PR introduces a breaking change

<!-- If yes, describe what breaks and the migration path. -->

## Checklist
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [ ] Types are correct — `pnpm typecheck` passes
- [ ] No lint errors — `pnpm lint:check` passes
- [ ] Tests added / updated for changed behaviour
- [ ] `pnpm test:cov` passes with ≥ 80 % coverage
- [ ] Public API changes are reflected in the README
